### PR TITLE
Fix readme: change onFinish call to assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ npm i @cloudflare/speedtest
 ```js
 import SpeedTest from '@cloudflare/speedtest';
 
-new SpeedTest()
-  .onFinish(results => console.log(results.getSummary()));
+new SpeedTest().onFinish = results => console.log(results.getSummary());
 ```
 
 ## API reference


### PR DESCRIPTION
MeasurementEngine.onFinish [is a setter](https://github.com/cloudflare/speedtest/blob/25be96439f9bd4ac2dbb9af574cdf1e23243bb24/src/index.js#L44), so calling it does not work.

This PR addresses that and sets onFinish to a callback in the main example