### PR TITLE
Expose estimatedServerTime as a configurable parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,25 +37,25 @@ new SpeedTest().onFinish = results => console.log(results.getSummary());
 new SpeedTest({ configOptions })
 ```
 
-| Config option                                        | Description                                                                                                                                                                                                         |                Default                |
-|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------:|
-| <b>autoStart</b>: <i>boolean</i>                     | Whether to automatically start the measurements on instantiation.                                                                                                                                                   |                `true`                 |
-| <b>downloadApiUrl</b>: <i>string</i>                 | The URL of the API for performing download GET requests.                                                                                                                                                            | `https://speed.cloudflare.com/__down` |
-| <b>uploadApiUrl</b>: <i>string</i>                   | The URL of the API for performing upload POST requests.                                                                                                                                                             |  `https://speed.cloudflare.com/__up`  |
-| <b>turnServerUri</b>: <i>string</i>                  | The URI of the TURN server used to measure packet loss.                                                                                                                                                             |   `turn.speed.cloudflare.com:50000`   |
-| <b>turnServerUser</b>: <i>string</i>                 | The username for the TURN server credentials.                                                                                                                                                                       |                   -                   |
-| <b>turnServerPass</b>: <i>string</i>                 | The password for the TURN server credentials.                                                                                                                                                                       |                   -                   |
-| <b>measurements</b>: <i>array</i>                    | The sequence of measurements to perform by the speedtest engine. See [below](#measurement-config) for the specific syntax of this option.                                                                           |                                       |
-| <b>measureDownloadLoadedLatency</b>: <i>boolean</i>  | Whether to perform additional latency measurements simultaneously with download requests, to measure loaded latency (during download).                                                                              |                `true`                 |
-| <b>measureUploadLoadedLatency</b>: <i>boolean</i>    | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload).                                                                                  |                `true`                 |
-| <b>loadedLatencyThrottle</b>: <i>number</i>          | Time interval to wait in between loaded latency requests (in milliseconds).                                                                                                                                         |                  400                  |
-| <b>bandwidthFinishRequestDuration</b>: <i>number</i> | The minimum duration (in milliseconds) to reach in download/upload measurement sets for halting further measurements with larger file sizes in the same direction.                                                  |                 1000                  |
-| <b>estimatedServerTime</b>: <i>number</i>            | If the download/upload APIs do not return a server-timing response header containing the time spent in the server, this fixed value (in milliseconds) will be subtracted from all time-to-first-byte calculations.  |                  10                   |
-| <b>latencyPercentile</b>: <i>number</i>              | The percentile (between 0 and 1) used to calculate latency from a set of measurements.                                                                                                                              |                  0.5                  |
-| <b>bandwidthPercentile</b>: <i>number</i>            | The percentile (between 0 and 1) used to calculate bandwidth from a set of measurements.                                                                                                                            |                  0.9                  |
-| <b>bandwidthMinRequestDuration</b>: <i>number</i>    | The minimum duration (in milliseconds) of a request to consider a measurement good enough to use in the bandwidth calculation.                                                                                      |                  10                   |
-| <b>loadedRequestMinDuration</b>: <i>number</i>       | The minimum duration (in milliseconds) of a request to consider it to be loading the connection.                                                                                                                    |                  250                  |
-| <b>loadedLatencyMaxPoints</b>: <i>number</i>         | The maximum number of data points to keep for loaded latency measurements. When more than this amount are available, the latest ones are kept.                                                                      |                  20                   |
+| Config option | Description | Default |
+| --- | --- | :--: |
+| <b>autoStart</b>: <i>boolean</i> | Whether to automatically start the measurements on instantiation. | `true` |
+| <b>downloadApiUrl</b>: <i>string</i> | The URL of the API for performing download GET requests. | `https://speed.cloudflare.com/__down` |
+| <b>uploadApiUrl</b>: <i>string</i> | The URL of the API for performing upload POST requests. | `https://speed.cloudflare.com/__up` |
+| <b>turnServerUri</b>: <i>string</i> | The URI of the TURN server used to measure packet loss. | `turn.speed.cloudflare.com:50000` |
+| <b>turnServerUser</b>: <i>string</i> | The username for the TURN server credentials. | - |
+| <b>turnServerPass</b>: <i>string</i> | The password for the TURN server credentials. | - |
+| <b>measurements</b>: <i>array</i> | The sequence of measurements to perform by the speedtest engine. See [below](#measurement-config) for the specific syntax of this option. ||
+| <b>measureDownloadLoadedLatency</b>: <i>boolean</i> | Whether to perform additional latency measurements simultaneously with download requests, to measure loaded latency (during download). | `true` |
+| <b>measureUploadLoadedLatency</b>: <i>boolean</i> | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload). | `true` |
+| <b>loadedLatencyThrottle</b>: <i>number</i> | Time interval to wait in between loaded latency requests (in milliseconds). | 400 |
+| <b>bandwidthFinishRequestDuration</b>: <i>number</i> | The minimum duration (in milliseconds) to reach in download/upload measurement sets for halting further measurements with larger file sizes in the same direction. | 1000 |
+| <b>estimatedServerTime</b>: <i>number</i> | If the download/upload APIs do not return a server-timing response header containing the time spent in the server, this fixed value (in milliseconds) will be subtracted from all time-to-first-byte calculations. | 10 |
+| <b>latencyPercentile</b>: <i>number</i> | The percentile (between 0 and 1) used to calculate latency from a set of measurements. | 0.5 |
+| <b>bandwidthPercentile</b>: <i>number</i> | The percentile (between 0 and 1) used to calculate bandwidth from a set of measurements. | 0.9 |
+| <b>bandwidthMinRequestDuration</b>: <i>number</i> | The minimum duration (in milliseconds) of a request to consider a measurement good enough to use in the bandwidth calculation. | 10 |
+| <b>loadedRequestMinDuration</b>: <i>number</i> | The minimum duration (in milliseconds) of a request to consider it to be loading the connection. | 250 |
+| <b>loadedLatencyMaxPoints</b>: <i>number</i> | The maximum number of data points to keep for loaded latency measurements. When more than this amount are available, the latest ones are kept. | 20 |
 
 ### Attributes
 | Attribute | Description |

--- a/README.md
+++ b/README.md
@@ -37,24 +37,25 @@ new SpeedTest().onFinish = results => console.log(results.getSummary());
 new SpeedTest({ configOptions })
 ```
 
-| Config option | Description | Default |
-| --- | --- | :--: |
-| <b>autoStart</b>: <i>boolean</i> | Whether to automatically start the measurements on instantiation. | `true` |
-| <b>downloadApiUrl</b>: <i>string</i> | The URL of the API for performing download GET requests. | `https://speed.cloudflare.com/__down` |
-| <b>uploadApiUrl</b>: <i>string</i> | The URL of the API for performing upload POST requests. | `https://speed.cloudflare.com/__up` |
-| <b>turnServerUri</b>: <i>string</i> | The URI of the TURN server used to measure packet loss. | `turn.speed.cloudflare.com:50000` |
-| <b>turnServerUser</b>: <i>string</i> | The username for the TURN server credentials. | - |
-| <b>turnServerPass</b>: <i>string</i> | The password for the TURN server credentials. | - |
-| <b>measurements</b>: <i>array</i> | The sequence of measurements to perform by the speedtest engine. See [below](#measurement-config) for the specific syntax of this option. ||
-| <b>measureDownloadLoadedLatency</b>: <i>boolean</i> | Whether to perform additional latency measurements simultaneously with download requests, to measure loaded latency (during download). | `true` |
-| <b>measureUploadLoadedLatency</b>: <i>boolean</i> | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload). | `true` |
-| <b>loadedLatencyThrottle</b>: <i>number</i> | Time interval to wait in between loaded latency requests (in milliseconds). | 400 |
-| <b>bandwidthFinishRequestDuration</b>: <i>number</i> | The minimum duration (in milliseconds) to reach in download/upload measurement sets for halting further measurements with larger file sizes in the same direction. | 1000 |
-| <b>latencyPercentile</b>: <i>number</i> | The percentile (between 0 and 1) used to calculate latency from a set of measurements. | 0.5 |
-| <b>bandwidthPercentile</b>: <i>number</i> | The percentile (between 0 and 1) used to calculate bandwidth from a set of measurements. | 0.9 |
-| <b>bandwidthMinRequestDuration</b>: <i>number</i> | The minimum duration (in milliseconds) of a request to consider a measurement good enough to use in the bandwidth calculation. | 10 |
-| <b>loadedRequestMinDuration</b>: <i>number</i> | The minimum duration (in milliseconds) of a request to consider it to be loading the connection. | 250 |
-| <b>loadedLatencyMaxPoints</b>: <i>number</i> | The maximum number of data points to keep for loaded latency measurements. When more than this amount are available, the latest ones are kept. | 20 |
+| Config option                                        | Description                                                                                                                                                                                                         |                Default                |
+|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------:|
+| <b>autoStart</b>: <i>boolean</i>                     | Whether to automatically start the measurements on instantiation.                                                                                                                                                   |                `true`                 |
+| <b>downloadApiUrl</b>: <i>string</i>                 | The URL of the API for performing download GET requests.                                                                                                                                                            | `https://speed.cloudflare.com/__down` |
+| <b>uploadApiUrl</b>: <i>string</i>                   | The URL of the API for performing upload POST requests.                                                                                                                                                             |  `https://speed.cloudflare.com/__up`  |
+| <b>turnServerUri</b>: <i>string</i>                  | The URI of the TURN server used to measure packet loss.                                                                                                                                                             |   `turn.speed.cloudflare.com:50000`   |
+| <b>turnServerUser</b>: <i>string</i>                 | The username for the TURN server credentials.                                                                                                                                                                       |                   -                   |
+| <b>turnServerPass</b>: <i>string</i>                 | The password for the TURN server credentials.                                                                                                                                                                       |                   -                   |
+| <b>measurements</b>: <i>array</i>                    | The sequence of measurements to perform by the speedtest engine. See [below](#measurement-config) for the specific syntax of this option.                                                                           |                                       |
+| <b>measureDownloadLoadedLatency</b>: <i>boolean</i>  | Whether to perform additional latency measurements simultaneously with download requests, to measure loaded latency (during download).                                                                              |                `true`                 |
+| <b>measureUploadLoadedLatency</b>: <i>boolean</i>    | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload).                                                                                  |                `true`                 |
+| <b>loadedLatencyThrottle</b>: <i>number</i>          | Time interval to wait in between loaded latency requests (in milliseconds).                                                                                                                                         |                  400                  |
+| <b>bandwidthFinishRequestDuration</b>: <i>number</i> | The minimum duration (in milliseconds) to reach in download/upload measurement sets for halting further measurements with larger file sizes in the same direction.                                                  |                 1000                  |
+| <b>estimatedServerTime</b>: <i>number</i>            | If the download/upload APIs do not return a server-timing response header containing the time spent in the server, this fixed value (in milliseconds) will be subtracted from all time-to-first-byte calculations.  |                  10                   |
+| <b>latencyPercentile</b>: <i>number</i>              | The percentile (between 0 and 1) used to calculate latency from a set of measurements.                                                                                                                              |                  0.5                  |
+| <b>bandwidthPercentile</b>: <i>number</i>            | The percentile (between 0 and 1) used to calculate bandwidth from a set of measurements.                                                                                                                            |                  0.9                  |
+| <b>bandwidthMinRequestDuration</b>: <i>number</i>    | The minimum duration (in milliseconds) of a request to consider a measurement good enough to use in the bandwidth calculation.                                                                                      |                  10                   |
+| <b>loadedRequestMinDuration</b>: <i>number</i>       | The minimum duration (in milliseconds) of a request to consider it to be loading the connection.                                                                                                                    |                  250                  |
+| <b>loadedLatencyMaxPoints</b>: <i>number</i>         | The maximum number of data points to keep for loaded latency measurements. When more than this amount are available, the latest ones are kept.                                                                      |                  20                   |
 
 ### Attributes
 | Attribute | Description |

--- a/src/config/defaultConfig.js
+++ b/src/config/defaultConfig.js
@@ -45,6 +45,7 @@ export default {
   measureUploadLoadedLatency: true,
   loadedLatencyThrottle: 400, // ms in between loaded latency requests
   bandwidthFinishRequestDuration: 1000, // download/upload duration (ms) to reach for stopping further measurements
+  estimatedServerTime: 10, // ms to discount from latency calculation (if not present in response headers)
 
   // Result interpretation
   latencyPercentile: 0.5, // Percentile used to calculate latency from a set of measurements

--- a/src/engines/BandwidthEngine/ParallelLatency.js
+++ b/src/engines/BandwidthEngine/ParallelLatency.js
@@ -8,12 +8,14 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
       parallelLatencyThrottleMs = 100,
       downloadApiUrl,
       uploadApiUrl,
+      estimatedServerTime = 0,
       ...ptProps
     } = {}
   ) {
     super(measurements, {
       downloadApiUrl,
       uploadApiUrl,
+      estimatedServerTime,
       ...ptProps
     });
 
@@ -27,7 +29,12 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
             bypassMinDuration: true
           }
         ],
-        { downloadApiUrl, uploadApiUrl, throttleMs: parallelLatencyThrottleMs }
+        {
+          downloadApiUrl,
+          uploadApiUrl,
+          estimatedServerTime,
+          throttleMs: parallelLatencyThrottleMs
+        }
       );
       this.#latencyEngine.qsParams = {
         during: `${measurements[0].dir}load`

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,7 @@ export interface ConfigOptions {
   measureUploadLoadedLatency?: boolean,
   loadedLatencyThrottle?: number,
   bandwidthFinishRequestDuration?: number,
+  estimatedServerTime?: number;
 
   // Result interpretation
   latencyPercentile?: number,

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ class MeasurementEngine {
     const { type, ...msmConfig } = this.#config.measurements[this.#curMsmIdx];
     const msmResults = this.#curTypeResults();
 
-    const { downloadApiUrl, uploadApiUrl } = this.#config;
+    const { downloadApiUrl, uploadApiUrl, estimatedServerTime } = this.#config;
 
     let engine;
     switch (type) {
@@ -292,6 +292,7 @@ class MeasurementEngine {
           {
             downloadApiUrl,
             uploadApiUrl,
+            estimatedServerTime,
             logApiUrl: this.#config.logMeasurementApiUrl,
             measurementId: this.#measurementId,
 
@@ -347,6 +348,7 @@ class MeasurementEngine {
             {
               downloadApiUrl,
               uploadApiUrl,
+              estimatedServerTime,
               logApiUrl: this.#config.logMeasurementApiUrl,
               measurementId: this.#measurementId,
               measureParallelLatency,


### PR DESCRIPTION
The configuration object now supports an additional parameter `estimatedServerTime` which allows the consumer to specify the estimated duration that the download/upload requests spend in the server, in case the `server-timing` is not specifically set on the response header.