### PR TITLE
Set 0 points to packet loss AIM score in case of ICE connection error

### DIFF
--- a/src/Results/ScoresCalculations.js
+++ b/src/Results/ScoresCalculations.js
@@ -13,6 +13,10 @@ const customResultTypes = {
       : undefined
 };
 
+const defaultPoints = {
+  packetLoss: 0
+};
+
 class ScoresCalculations {
   constructor(config) {
     this.#config = config;
@@ -26,7 +30,9 @@ class ScoresCalculations {
             ? customResultTypes[type](measurements)
             : measurements[type];
           return val === undefined
-            ? {}
+            ? defaultPoints.hasOwnProperty(type)
+              ? { [type]: defaultPoints[type] }
+              : {}
             : {
                 [type]: val === undefined ? 0 : +fn(val)
               };


### PR DESCRIPTION
When the packet loss test fails with "ICE connection timeout", the network quality scores aren't reported at the end of the test.

This is usually related to network issues and justify treating this situation as "0 points" in the packet loss AIM item.