### PR TITLE
Fix Issues with BandwidthMeasurementEngine stop method and Performance API

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -271,6 +271,9 @@ class BandwidthMeasurementEngine {
       this.#fetchOptions
     );
 
+    // Mark the start of the request
+    performance.mark(`${url}-start`);
+
     let serverTime;
     const curPromise = (this.#currentFetchPromise = fetch(url, fetchOpt) // eslint-disable-line compat/compat
       .then(r => {

--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -123,6 +123,10 @@ class BandwidthMeasurementEngine {
     this.#setRunning(false);
   }
 
+  stop() {
+    this.pause();
+  }
+
   play() {
     if (!this.#running) {
       this.#setRunning(true);

--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -277,6 +277,9 @@ class BandwidthMeasurementEngine {
     let serverTime;
     const curPromise = (this.#currentFetchPromise = fetch(url, fetchOpt) // eslint-disable-line compat/compat
       .then(r => {
+        // Mark the end of the request and measure the duration
+        performance.mark(`${url}-end`);
+        performance.measure(url, `${url}-start`, `${url}-end`);
         if (r.ok) return r;
         throw Error(r.statusText);
       })


### PR DESCRIPTION
* First, there no stop method in `BandwidthMeasurementEngine` class. Stop method of this class is called `onConnectionError`, as shown in the following links::
https://github.com/cloudflare/speedtest/blob/main/src/engines/BandwidthEngine/ParallelLatency.js#L44
https://github.com/cloudflare/speedtest/blob/main/src/engines/BandwidthEngine/ParallelLatency.js#L78
I added stop method which calls `this.pause()`, which may need to be updated accordingly. See: 
https://github.com/bekmuradov/speedtest/blob/main/src/engines/BandwidthEngine/BandwidthEngine.js#L126-L128
* Secondly. The `performance.getEntriesByName()` method is returning an empty array, which means there are no timing entries with the specified url. As a result, when attempting to access .slice(-1)[0], it shows warning message and there is no timing data. To fix these issues, we need to ensure that the Performance API is correctly capturing the timing entries for each request. 
  - create a performance entry using performance.mark() before making the fetch request and set an identifier for the entry.
  - After receiving the fetch response, create another performance entry using performance.mark() and performance.measure() to calculate the duration of the request.