### PR TITLE
Fix Issue 44 - Pause tests when the page is not visible to stop leaking timers

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -63,6 +63,8 @@ class BandwidthMeasurementEngine {
     this.#uploadApi = uploadApiUrl;
     this.#throttleMs = throttleMs;
     this.#estimatedServerTime = Math.max(0, estimatedServerTime);
+
+    document.addEventListener('visibilitychange', this.#handleVisibilityChange);
   }
 
   // Public attributes
@@ -86,6 +88,14 @@ class BandwidthMeasurementEngine {
   set fetchOptions(v) {
     this.#fetchOptions = v;
   }
+
+  #handleVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      this.pause();
+    } else if (document.visibilityState === 'visible') {
+      this.play();
+    }
+  };
 
   finishRequestDuration = 1000; // download/upload duration (ms) to reach for stopping further measurements
   getServerTime = cfGetServerTime; // method to extract server time from response
@@ -370,6 +380,13 @@ class BandwidthMeasurementEngine {
   #cancelCurrentMeasurement() {
     const curPromise = this.#currentFetchPromise;
     curPromise && (curPromise._cancel = true);
+  }
+
+  deleteEventListener() {
+    document.removeEventListener(
+      'visibilitychange',
+      this.#handleVisibilityChange
+    );
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -330,6 +330,7 @@ class MeasurementEngine {
           msmResults.finished = true;
           this.onResultsChange({ type });
           this.#running && this.#next();
+          engine.deleteEventListener();
         };
 
         engine.onConnectionError = e => {
@@ -443,6 +444,7 @@ class MeasurementEngine {
             }
 
             this.#running && this.#next();
+            engine.deleteEventListener();
           };
 
           engine.onConnectionError = e => {


### PR DESCRIPTION
To Fix Issue 44: https://github.com/cloudflare/speedtest/issues/44 

Adding an event listener to determine if the page of the test is visible or not and pause/play the test accordingly.