### PR TITLE
Revert adding visibility change event listener

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -63,13 +63,6 @@ class BandwidthMeasurementEngine {
     this.#uploadApi = uploadApiUrl;
     this.#throttleMs = throttleMs;
     this.#estimatedServerTime = Math.max(0, estimatedServerTime);
-
-    if (typeof document !== 'undefined') {
-      document.addEventListener(
-        'visibilitychange',
-        this.#handleVisibilityChange
-      );
-    }
   }
 
   // Public attributes
@@ -93,20 +86,6 @@ class BandwidthMeasurementEngine {
   set fetchOptions(v) {
     this.#fetchOptions = v;
   }
-
-  #handleVisibilityChange = () => {
-    if (
-      typeof document !== 'undefined' &&
-      document.visibilityState === 'hidden'
-    ) {
-      this.pause();
-    } else if (
-      typeof document !== 'undefined' &&
-      document.visibilityState === 'visible'
-    ) {
-      this.play();
-    }
-  };
 
   finishRequestDuration = 1000; // download/upload duration (ms) to reach for stopping further measurements
   getServerTime = cfGetServerTime; // method to extract server time from response
@@ -391,15 +370,6 @@ class BandwidthMeasurementEngine {
   #cancelCurrentMeasurement() {
     const curPromise = this.#currentFetchPromise;
     curPromise && (curPromise._cancel = true);
-  }
-
-  deleteEventListener() {
-    if (typeof document !== 'undefined') {
-      document.removeEventListener(
-        'visibilitychange',
-        this.#handleVisibilityChange
-      );
-    }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,6 @@ class MeasurementEngine {
           msmResults.finished = true;
           this.onResultsChange({ type });
           this.#running && this.#next();
-          engine.deleteEventListener();
         };
 
         engine.onConnectionError = e => {
@@ -444,7 +443,6 @@ class MeasurementEngine {
             }
 
             this.#running && this.#next();
-            engine.deleteEventListener();
           };
 
           engine.onConnectionError = e => {


### PR DESCRIPTION
Reverting https://github.com/cloudflare/speedtest/pull/46 because of https://github.com/cloudflare/speedtest/issues/49 i can reproduce the issue. The event listeners are not cleared 100% after the test which causes the test to play once the page is on focus again. 