### PR TITLE
Fix race condition on BandwidthWithParallelLatencyEngine

### DIFF
--- a/src/engines/BandwidthEngine/ParallelLatency.js
+++ b/src/engines/BandwidthEngine/ParallelLatency.js
@@ -82,14 +82,19 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
 
   // Internal state
   #latencyEngine;
+  #latencyTimeout;
 
   // Internal methods
   #setLatencyRunning(running) {
-    this.#latencyEngine &&
-      (!running
-        ? this.#latencyEngine.pause()
-        : // slight delay in starting latency measurements
-          setTimeout(() => this.#latencyEngine.play(), 20));
+    if (this.#latencyEngine) {
+      if (!running) {
+        clearTimeout(this.#latencyTimeout);
+        this.#latencyEngine.pause();
+      } else {
+        // slight delay in starting latency measurements
+        this.#latencyTimeout = setTimeout(() => this.#latencyEngine.play(), 20);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fix race condition on BandwidthWithParallelLatencyEngine that keeps latency measurements running after the test is paused or finished.

Fixes #48
Should fix #49 