### PR TITLE
Add bandwidthAbortRequestDuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ new SpeedTest({ configOptions })
 | **measureUploadLoadedLatency**: *boolean* | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload). | `true` |
 | **loadedLatencyThrottle**: *number* | Time interval to wait in between loaded latency requests (in milliseconds). | 400 |
 | **bandwidthFinishRequestDuration**: *number* | The minimum duration (in milliseconds) to reach in download/upload measurement sets for halting further measurements with larger file sizes in the same direction. | 1000 |
+| **bandwidthAbortRequestDuration**: *number* | The minimum duration (in milliseconds) to reach in download/upload measurement sets for aborting the test early | 0 (disabled) |
 | **estimatedServerTime**: *number* | If the download/upload APIs do not return a server-timing response header containing the time spent in the server, this fixed value (in milliseconds) will be subtracted from all time-to-first-byte calculations. | 10 |
 | **latencyPercentile**: *number* | The percentile (between 0 and 1) used to calculate latency from a set of measurements. | 0.5 |
 | **bandwidthPercentile**: *number* | The percentile (between 0 and 1) used to calculate bandwidth from a set of measurements. | 0.9 |

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,8 @@ export default [
     output: [
       {
         format: 'es',
-        file: `dist/${fileName}.js`
+        file: `dist/${fileName}.js`,
+        sourcemap: true
       }
     ],
     external: [...Object.keys(dependencies || {})],

--- a/src/config/defaultConfig.js
+++ b/src/config/defaultConfig.js
@@ -45,8 +45,11 @@ export default {
   measureDownloadLoadedLatency: true,
   measureUploadLoadedLatency: true,
   loadedLatencyThrottle: 400, // ms in between loaded latency requests
-  bandwidthFinishRequestDuration: 1000, // download/upload duration (ms) to reach for stopping further measurements
+  bandwidthFinishRequestDuration: 1000, // download/upload duration (ms) to reach for stopping further measurements of that type
   estimatedServerTime: 10, // ms to discount from latency calculation (if not present in response headers)
+
+  // Test abort
+  bandwidthAbortRequestDuration: 0, // download/upload duration (ms) to abort measurement early and stop further measurements of that type
 
   // Result interpretation
   latencyPercentile: 0.5, // Percentile used to calculate latency from a set of measurements

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,7 @@ export interface ConfigOptions {
   measureUploadLoadedLatency?: boolean,
   loadedLatencyThrottle?: number,
   bandwidthFinishRequestDuration?: number,
+  bandwidthAbortRequestDuration?: number,
   estimatedServerTime?: number;
 
   // Result interpretation
@@ -112,6 +113,7 @@ declare class SpeedTestEngine {
 
   onRunningChange: (running: boolean) => void;
   onResultsChange: ({ type: string }) => void;
+  onPhaseChange: ({ measurement: MeasurementConfig, measurementId: number }) => void;
   onFinish: (results: Results) => void;
   onError: (error: string) => void;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ class MeasurementEngine {
 
   onRunningChange = () => {};
   onResultsChange = () => {};
+  onPhaseChange = () => {};
 
   #onFinish = () => {}; // callback invoked when all the measurements are finished
   set onFinish(f) {
@@ -58,6 +59,12 @@ class MeasurementEngine {
 
   play() {
     if (!this.#running) {
+      // Clear timings before running the engine
+      performance.clearResourceTimings();
+
+      // Default is 250. This can mean the buffer is filled between measurements if many requests are being done
+      // in the same page the engine is running.
+      performance.setResourceTimingBufferSize(10000);
       this.#setRunning(true);
       this.#next();
     }
@@ -158,6 +165,11 @@ class MeasurementEngine {
 
     const { type, ...msmConfig } = this.#config.measurements[this.#curMsmIdx];
     const msmResults = this.#curTypeResults();
+
+    this.onPhaseChange({
+      measurementId: this.#curMsmIdx,
+      measurement: { type, ...msmConfig }
+    });
 
     const { downloadApiUrl, uploadApiUrl, estimatedServerTime } = this.#config;
 
@@ -318,6 +330,8 @@ class MeasurementEngine {
         engine.fetchOptions = {
           credentials: this.#config.includeCredentials ? 'include' : undefined
         };
+        engine.abortRequestDuration =
+          this.#config.bandwidthAbortRequestDuration;
 
         engine.onMeasurementResult = engine.onNewMeasurementStarted = (
           meas,
@@ -372,6 +386,8 @@ class MeasurementEngine {
           };
           engine.finishRequestDuration =
             this.#config.bandwidthFinishRequestDuration;
+          engine.abortRequestDuration =
+            this.#config.bandwidthAbortRequestDuration;
 
           engine.onNewMeasurementStarted = ({ count, bytes }) => {
             const res = (msmResults.results = Object.assign(


### PR DESCRIPTION
This PR adds a bandwidthAbortRequestDuration that will abort the current measurement tier early in case a request exceeds the set amount of time.

The feature prevents tests hanging forever in extremely limited network conditions.