### PR TITLE
Switch to blob().text() for faster fetch parsing

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -278,15 +278,18 @@ class BandwidthMeasurementEngine {
         return r;
       })
       .then(r =>
-        r.text().then(body => {
-          this.#responseHook &&
-            this.#responseHook({
-              url,
-              headers: r.headers,
-              body
+        r.blob().then(blob => {
+          if (this.#responseHook) {
+            blob.text().then(body => {
+              this.#responseHook({
+                url,
+                headers: r.headers,
+                body
+              });
             });
+          }
 
-          return body;
+          return blob;
         })
       )
       .then((_, reject) => {


### PR DESCRIPTION
I noticed that download speeds were significantly slower than expected (and much slower than upload speeds) when testing against a local Go-based backend.

It turns out `response.text()` creates significant backpressure. Because JS handles the text chunks slower than the network can deliver them, it throttles the actual TCP connection. Using `response.blob().text()` avoids JS backpressure and results in a more accurate network speed measurement.

In local tests, the difference is substantial – around a 9-10x improvement. Below is a simple benchmark run in Chrome on a MacBook M4 Pro downloading a 100MB payload:
<img width="717" height="211" alt="Screenshot 2026-02-02 at 9 39 16 AM" src="https://github.com/user-attachments/assets/c77fa3cc-8228-4d89-9d6f-3ccd8b38fe06" />

