### PR TITLE
bandwidthAbortRequestDuration fixes

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -395,7 +395,9 @@ class BandwidthMeasurementEngine {
   }
 
   #cancelCurrentMeasurement() {
-    this.#currentAbortController.abort();
+    if (this.#currentAbortController) {
+      this.#currentAbortController.abort();
+    }
   }
 }
 

--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -150,6 +150,7 @@ class BandwidthMeasurementEngine {
    * @type AbortController
    */
   #currentAbortController = undefined;
+  #currentAbortTimeout = undefined;
 
   // Internal methods
   #setRunning(running) {
@@ -275,7 +276,7 @@ class BandwidthMeasurementEngine {
     if (this.#retries === 0) {
       this.#currentAbortController = new AbortController();
       if (this.abortRequestDuration) {
-        const abortTimeout = setTimeout(() => {
+        this.#currentAbortTimeout = setTimeout(() => {
           this.#cancelCurrentMeasurement();
           this.#retries = 0;
           this.#setRunning(false);
@@ -284,7 +285,7 @@ class BandwidthMeasurementEngine {
           );
         }, this.abortRequestDuration);
         this.#currentAbortController.signal.addEventListener('abort', () =>
-          clearTimeout(abortTimeout)
+          clearTimeout(this.#currentAbortTimeout)
         );
       }
     }
@@ -361,6 +362,7 @@ class BandwidthMeasurementEngine {
 
         this.#counter += 1;
         this.#retries = 0;
+        clearTimeout(this.#currentAbortTimeout);
 
         if (this.#throttleMs) {
           const throttleTimeout = setTimeout(


### PR DESCRIPTION
bandwidthAbortRequestDuration: fix undefined dereference

    add check if abortController exists before calling .abort()

    this seems to be a race condition and i don't know the codebase well
    enough to really understand how it happens.
    but there should be no harm not aborting the request when there is no
    abortcontroller.

    fixes: https://github.com/cloudflare/speedtest/issues/77

bandwidthAbortRequestDuration: fix wrongly throwing error when not aborted

    The abortTimeout is only canceled when the request is aborted.
    Also cancel it when the measurement is finished.
    retries == 0 is when the measurement is started, so when retries is set
    back to 0, the measurement is finished, add clearTimeout here.

    fixes: https://github.com/cloudflare/speedtest/issues/77
    
fixes: https://github.com/cloudflare/speedtest/issues/77
