### PR TITLE
Switch to blob().text() for faster fetch parsing

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -303,15 +303,17 @@ class BandwidthMeasurementEngine {
         return r;
       })
       .then(r =>
-        r.text().then(body => {
-          this.#responseHook &&
-            this.#responseHook({
-              url,
-              headers: r.headers,
-              body
+        r.blob().then(blob => {
+          if (this.#responseHook) {
+            blob.text().then(body => {
+              this.#responseHook({
+                url,
+                headers: r.headers,
+                body
+              });
             });
-
-          return body;
+          }
+          return blob;
         })
       )
       .then(() => {


### PR DESCRIPTION
This PR improves download speed measurement accuracy by replacing `response.text()` with `response.blob().text()`.

`response.text()` was introducing significant JS-side backpressure, which throttled the effective TCP throughput and caused download measurements to be much lower than expected. Using `response.blob().text()` avoids that issue and produces more accurate results.

Original PR : dmeremianina

Semver label: `patch`

It looks like there are no available semver labels, or I don’t have permission to add them. Could a maintainer please add the `patch` label? This PR is a non-breaking performance improvement.


