### PR TITLE
fix(ci): release PR workflow fixes

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -33,6 +33,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore: bump version to ${{ steps.bump.outputs.version }}"
@@ -43,3 +44,15 @@ jobs:
             Automated release PR for v${{ steps.bump.outputs.version }}.
 
             Merge this PR to publish to npm.
+
+      # PRs created by GITHUB_TOKEN don't trigger other workflows.
+      # Close and reopen the PR to trigger CI status checks.
+      - name: Trigger CI checks
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=${{ steps.create-pr.outputs.pull-request-number }}
+          gh pr close "$PR" --repo "${{ github.repository }}"
+          sleep 2
+          gh pr reopen "$PR" --repo "${{ github.repository }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,5 +51,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Fix 1: Trigger CI checks on release PRs

PRs created by `GITHUB_TOKEN` don't trigger other workflows ([GitHub Actions limitation](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) to prevent infinite loops). This means when the "Create Release PR" workflow creates a release PR, the Build workflow never fires, and the required status checks (`build (22.x)`, `build (24.x)`) stay stuck on "Waiting for status to be reported."

**Fix:** Close and reopen the PR after creation to trigger CI checks.

## Fix 2: Use OIDC provenance for npm publish

The previous (working) publish workflow authenticated via npm's [OIDC provenance](https://docs.npmjs.com/generating-provenance-statements) using the `id-token: write` permission — npm automatically detects the GitHub Actions OIDC token and uses it for authentication.

The new `publish.yml` was explicitly setting `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`, which overrides the OIDC mechanism and caused a `404 Not Found` error on publish (the `NPM_TOKEN` secret likely has wrong permissions or was never used for publishing).

**Fix:** Remove the explicit `NODE_AUTH_TOKEN` env var and let npm use OIDC provenance, matching the previous workflow's behavior.

Evidence from the successful v1.9.0 publish log:
```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
```