### PR TITLE
feat: add startApiUrl config to log test start events

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ new SpeedTest({ configOptions })
 | **autoStart**: *boolean* | Whether to automatically start the measurements on instantiation. | `true` |
 | **downloadApiUrl**: *string* | The URL of the API for performing download GET requests. | `https://speed.cloudflare.com/__down` |
 | **uploadApiUrl**: *string* | The URL of the API for performing upload POST requests. | `https://speed.cloudflare.com/__up` |
+| **startApiUrl**: *string* | URL to POST `{ measId }` when a speed test begins. Fires on the first `play()` and on `restart()`, but not on resume from pause. Fire-and-forget (non-blocking). | `null` (disabled) |
 | **turnServerUri**: *string* | The URI of the TURN server used to measure packet loss. | `turn.cloudflare.com:3478` |
 | **turnServerCredsApiUrl**: *string* | A URI that returns TURN server credentials. Expects a JSON response with `username` and `credential` keys. | - | 
 | **turnServerUser**: *string* | The username for the TURN server credentials. | - |
@@ -68,6 +69,7 @@ new SpeedTest({ configOptions })
 | **results**: *[Results](#results-object)* | Getter of the current [test results](#results-object) object. May yield incomplete values if the test is still running. |
 | **isRunning**: *boolean* | Getter of whether the test engine is currently running. |
 | **isFinished**: *boolean* | Getter of whether the test engine has finished all the measurements, and the results are considered final. |
+| **measurementId**: *string* | Getter of the current measurement's correlation ID. Regenerated on `restart()`. Matches the `measId` value sent to the start and logging APIs. |
 
 ### Methods
 

--- a/src/config/defaultConfig.js
+++ b/src/config/defaultConfig.js
@@ -7,6 +7,7 @@ export default {
   // APIs
   downloadApiUrl: `${REL_API_URL}/__down`,
   uploadApiUrl: `${REL_API_URL}/__up`,
+  startApiUrl: null,
   logMeasurementApiUrl: null,
   logAimApiUrl: 'https://aim.cloudflare.com/__log',
   turnServerUri: 'turn.speed.cloudflare.com:50000',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,6 +21,7 @@ export interface ConfigOptions {
   // APIs
   downloadApiUrl?: string,
   uploadApiUrl?: string,
+  startApiUrl?: string,
   turnServerUri?: string,
   turnServerUser?: string,
   turnServerPass?: string,
@@ -112,6 +113,7 @@ declare class SpeedTestEngine {
   readonly results: Results;
   readonly isRunning: boolean;
   readonly isFinished: boolean;
+  readonly measurementId: string;
 
   onRunningChange: (running: boolean) => void;
   onResultsChange: ({ type: string }) => void;

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,10 @@ class MeasurementEngine {
     return this.#finished;
   }
 
+  get measurementId() {
+    return this.#measurementId;
+  }
+
   onRunningChange = () => {};
   onResultsChange = () => {};
   onPhaseChange = () => {};
@@ -63,7 +67,21 @@ class MeasurementEngine {
       // Default is 250. This can mean the buffer is filled between measurements if many requests are being done
       // in the same page the engine is running.
       performance.setResourceTimingBufferSize(10000);
+
       this.#setRunning(true);
+
+      if (this.#config.startApiUrl && !this.#hasLoggedStart) {
+        this.#hasLoggedStart = true;
+        // credentials included because startApiUrl is typically same-origin,
+        // unlike logAimApiUrl which posts to a fixed cross-origin endpoint.
+        fetch(this.#config.startApiUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ measId: this.#measurementId }),
+          credentials: this.#config.includeCredentials ? 'include' : undefined
+        }).catch(() => {});
+      }
+
       this.#next();
     }
   }
@@ -77,6 +95,7 @@ class MeasurementEngine {
   #results;
 
   #measurementId = genMeasId();
+  #hasLoggedStart = false;
   #curMsmIdx = -1;
   #curEngine;
   #optimalDownloadChunkSize = DEFAULT_OPTIMAL_DOWNLOAD_SIZE;
@@ -143,6 +162,7 @@ class MeasurementEngine {
     this.#destroyCurEngine();
 
     this.#measurementId = genMeasId();
+    this.#hasLoggedStart = false;
     this.#curMsmIdx = -1;
     this.#curEngine = undefined;
 


### PR DESCRIPTION
## Summary

Add an optional `startApiUrl` configuration option that, when set, sends a POST request with the measurement ID when a speed test begins. This allows consumers to measure how many tests are started vs. completed.

## Changes

### `src/config/defaultConfig.js`
- Added `startApiUrl: null` to the default config (disabled by default)

### `src/index.js`
- Added `#hasLoggedStart` private flag to prevent duplicate start events
- In `play()`: if `startApiUrl` is configured and start hasn't been logged yet, fires a POST request with `{ measId }` in the JSON body. Fire-and-forget (non-blocking).
- In `#clear()` (called by `restart()`): resets the flag so the next `play()` logs a new start event with the regenerated measurement ID
- Added public `measurementId` getter

### `src/index.d.ts`
- Added `startApiUrl?: string` to `ConfigOptions`
- Added `readonly measurementId: string` to `SpeedTestEngine`

### `README.md`
- Documented `startApiUrl` in the Config Options table
- Documented `measurementId` in the Attributes table

## Behavior

| Scenario | Logs start? | Reason |
|---|---|---|
| First `play()` | Yes | `#hasLoggedStart` is `false` |
| Pause then resume | No | `#hasLoggedStart` is already `true` |
| `restart()` | Yes | `#clear()` resets flag + regenerates `measId` |
| `autoStart: true` | Yes | Constructor calls `play()` |
| `startApiUrl` not set | No | Feature is opt-in |

## Usage

```js
import SpeedTest from '@cloudflare/speedtest';

const engine = new SpeedTest({
  startApiUrl: '/__start' // POST { measId } sent on test start
});
```

## POST request format

```json
{
  "measId": "1234567890123456"
}
```

Follows the same fire-and-forget pattern as the existing final results logging.