### PR TITLE
test: add unit and e2e tests with Vitest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       run: pnpm test:unit
 
     - name: Install Playwright browsers
-      run: npx playwright install chromium
+      run: npx playwright install --with-deps chromium
 
     - name: E2E tests
       run: pnpm test:e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,12 @@ jobs:
 
     - name: Lint
       run: pnpm lint
+
+    - name: Unit tests
+      run: pnpm test:unit
+
+    - name: Install Playwright browsers
+      run: npx playwright install chromium
+
+    - name: E2E tests
+      run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /node_modules
 /dist
 /.idea
+
+# Test artifacts
+/test-results
+/playwright-report
+/.playwright
+/blob-report
+/coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,25 @@ pnpm build          # tsdown → dist/speedtest.js (ESM) + copies .d.ts
 pnpm dev            # tsdown watch mode
 pnpm lint           # eslint src/**/*.js *.json
 pnpm format         # prettier --write src/**/*.js
+pnpm test           # run all tests (unit + e2e)
+pnpm test:unit      # run unit tests only (fast, no browser)
+pnpm test:e2e       # run e2e tests only (Playwright, needs Chromium)
+pnpm test:watch     # run tests in watch mode
 ```
 
-There are **no tests** — no test framework, no test files, no test script.
+## Tests
+
+Uses **Vitest** with two test projects:
+
+- **Unit tests** (`tests/unit/**/*.test.ts`) — pure function tests for utils,
+  config, and Results. Run in Node, no browser needed. Fast.
+- **E2E tests** (`tests/e2e/*.test.ts`) — runs a minimal speed test in a real
+  Chromium browser via Vitest Browser Mode + Playwright. Tests the full library
+  integration (fetch, PerformanceResourceTiming, module loading).
+
+Test files are written in TypeScript (`.test.ts`). Source is still JS.
+
+To run e2e tests locally, install Chromium first: `npx playwright install chromium`
 
 ## Key constraints
 
@@ -52,6 +68,7 @@ Prettier + ESLint run on commit via `lint-staged` (Husky pre-commit hook).
 
 - PRs target `main`. Branch protection requires 1 approval and CI to pass.
 - CI runs `pnpm install && pnpm build && pnpm lint` on Node 22.x and 24.x.
+- CI also runs unit tests (`pnpm test:unit`) and e2e tests (`pnpm test:e2e`).
 - Releases are **manual**, not automatic per PR:
   1. Go to **Actions > "Create Release PR"** > pick `patch`/`minor`/`major` > Run.
   2. The workflow creates a `releases/v*` PR with the version bump.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
   "scripts": {
     "build": "tsdown && cp src/index.d.ts dist/speedtest.d.ts",
     "dev": "tsdown --watch",
+    "test": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:e2e": "vitest run --project e2e",
+    "test:watch": "vitest",
     "lint": "eslint \"src/**/*.js\" \"*.json\"",
     "format": "prettier --write \"src/**/*.js\"",
     "prepare": "husky && pnpm build"
@@ -45,6 +49,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.27.0",
+    "@vitest/browser-playwright": "^4.1.7",
     "eslint": "^9.27.0",
     "eslint-plugin-compat": "^6.0.2",
     "eslint-plugin-import": "^2.31.0",
@@ -52,9 +57,11 @@
     "eslint-plugin-prettier": "^5.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.0.0",
+    "playwright": "^1.60.0",
     "prettier": "^3.5.3",
     "tsdown": "^0.22.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.27.0
         version: 9.39.4
+      '@vitest/browser-playwright':
+        specifier: ^4.1.7
+        version: 4.1.7(playwright@1.60.0)(vite@8.0.14(yaml@2.9.0))(vitest@4.1.7)
       eslint:
         specifier: ^9.27.0
         version: 9.39.4
@@ -32,6 +35,9 @@ importers:
       lint-staged:
         specifier: ^16.0.0
         version: 16.4.0
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       prettier:
         specifier: ^3.5.3
         version: 3.8.3
@@ -41,6 +47,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@vitest/browser-playwright@4.1.7)(vite@8.0.14(yaml@2.9.0))
 
 packages:
 
@@ -73,6 +82,9 @@ packages:
   '@babel/types@8.0.0-rc.6':
     resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
     engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -166,6 +178,9 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
@@ -173,8 +188,17 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -182,10 +206,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-arm64@1.0.3':
     resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.3':
@@ -194,17 +230,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-freebsd-x64@1.0.3':
     resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
@@ -213,6 +268,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -220,10 +282,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -234,12 +310,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
@@ -248,21 +338,44 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-wasm32-wasi@1.0.3':
     resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
     resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
@@ -277,8 +390,17 @@ packages:
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -291,6 +413,46 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@vitest/browser-playwright@4.1.7':
+    resolution: {integrity: sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.7
+
+  '@vitest/browser@4.1.7':
+    resolution: {integrity: sha512-N2JFGfXoEGVAut+kHeru9dD4BUMq/q5xDvBARNl0tUsly3m5KglLOu8VO/6MkDfOlgxXTycojkt6gBKsuyR+IQ==}
+    peerDependencies:
+      vitest: 4.1.7
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -352,6 +514,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
     engines: {node: '>=20.19.0'}
@@ -409,6 +575,10 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -437,6 +607,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -485,6 +658,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -527,6 +704,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -658,6 +838,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -697,6 +881,16 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -945,6 +1139,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
@@ -971,6 +1239,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -985,8 +1256,17 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -1075,9 +1355,27 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1145,6 +1443,11 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1207,9 +1510,16 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
@@ -1218,6 +1528,16 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1271,6 +1591,9 @@ packages:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.2.2:
     resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
@@ -1278,6 +1601,14 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -1364,6 +1695,90 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-json-languageservice@4.2.1:
     resolution: {integrity: sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==}
 
@@ -1400,6 +1815,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -1407,6 +1827,18 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -1446,6 +1878,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 8.0.0-rc.6
       '@babel/helper-validator-identifier': 8.0.0-rc.6
+
+  '@blazediff/core@1.9.1': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1550,48 +1984,95 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@oxc-project/types@0.132.0': {}
+
   '@oxc-project/types@0.133.0': {}
 
   '@pkgr/core@0.3.6': {}
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
 
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.3':
@@ -1601,7 +2082,13 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
@@ -1611,10 +2098,19 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -1623,6 +2119,77 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@8.0.14(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(vite@8.0.14(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(vite@8.0.14(yaml@2.9.0))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@vitest/browser-playwright@4.1.7)(vite@8.0.14(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.7(vite@8.0.14(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.7(vite@8.0.14(yaml@2.9.0))
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@vitest/browser-playwright@4.1.7)(vite@8.0.14(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -1703,6 +2270,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-kit@3.0.0-beta.1:
     dependencies:
       '@babel/parser': 8.0.0-rc.4
@@ -1761,6 +2330,8 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -1786,6 +2357,8 @@ snapshots:
   commander@14.0.3: {}
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1834,6 +2407,8 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.7: {}
+
+  detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -1915,6 +2490,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -2080,6 +2657,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expect-type@1.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -2111,6 +2690,12 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -2356,6 +2941,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lint-staged@16.4.0:
     dependencies:
       commander: 14.0.3
@@ -2392,6 +3026,10 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   mimic-function@5.0.1: {}
@@ -2402,7 +3040,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
 
@@ -2500,7 +3142,23 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -2569,6 +3227,27 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
 
   rolldown@1.0.3:
     dependencies:
@@ -2670,7 +3349,15 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   slice-ansi@7.1.2:
     dependencies:
@@ -2681,6 +3368,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -2741,12 +3434,18 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.3.6
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  totalist@3.0.1: {}
 
   tree-kill@1.2.2: {}
 
@@ -2846,6 +3545,44 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite@8.0.14(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+      yaml: 2.9.0
+
+  vitest@4.1.7(@vitest/browser-playwright@4.1.7)(vite@8.0.14(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@8.0.14(yaml@2.9.0))(vitest@4.1.7)
+    transitivePeerDependencies:
+      - msw
+
   vscode-json-languageservice@4.2.1:
     dependencies:
       jsonc-parser: 3.3.1
@@ -2907,6 +3644,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@9.0.2:
@@ -2914,6 +3656,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.21.0: {}
 
   yaml@2.9.0: {}
 

--- a/tests/e2e/speedtest.test.ts
+++ b/tests/e2e/speedtest.test.ts
@@ -3,7 +3,8 @@ import SpeedTest from '../../src/index.js';
 
 describe('SpeedTest E2E', () => {
   it('runs a minimal speed test and produces valid results', {
-    timeout: 60_000
+    timeout: 60_000,
+    retry: 2
   }, async () => {
     const engine = new SpeedTest({
       autoStart: false,

--- a/tests/e2e/speedtest.test.ts
+++ b/tests/e2e/speedtest.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import SpeedTest from '../../src/index.js';
+
+describe('SpeedTest E2E', () => {
+  it('runs a minimal speed test and produces valid results', {
+    timeout: 60_000
+  }, async () => {
+    const engine = new SpeedTest({
+      autoStart: false,
+      logAimApiUrl: null,
+      logMeasurementApiUrl: null,
+      measurements: [
+        { type: 'latency', numPackets: 3 },
+        { type: 'download', bytes: 1e5, count: 1, bypassMinDuration: true }
+      ]
+    });
+
+    const results = await new Promise<ReturnType<typeof engine.results.getSummary>>(
+      (resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('Speed test timed out after 30 seconds'));
+        }, 30_000);
+
+        engine.onFinish = results => {
+          clearTimeout(timeout);
+          resolve(results.getSummary());
+        };
+
+        engine.onError = error => {
+          clearTimeout(timeout);
+          reject(new Error(`Speed test error: ${error}`));
+        };
+
+        engine.play();
+      }
+    );
+
+    // Verify latency results
+    expect(results.latency).toBeDefined();
+    expect(typeof results.latency).toBe('number');
+    expect(results.latency).toBeGreaterThan(0);
+
+    // Verify jitter results
+    expect(results.jitter).toBeDefined();
+    expect(typeof results.jitter).toBe('number');
+    expect(results.jitter).toBeGreaterThanOrEqual(0);
+
+    // Verify download results
+    expect(results.download).toBeDefined();
+    expect(typeof results.download).toBe('number');
+    expect(results.download).toBeGreaterThan(0);
+
+    // Verify total duration
+    expect(results.totalDurationMs).toBeDefined();
+    expect(results.totalDurationMs).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/Results/MeasurementCalculations.test.ts
+++ b/tests/unit/Results/MeasurementCalculations.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import MeasurementCalculations from '../../../src/Results/MeasurementCalculations.js';
+
+const defaultCalcConfig = {
+  latencyPercentile: 0.5,
+  bandwidthPercentile: 0.9,
+  bandwidthMinRequestDuration: 10,
+  loadedRequestMinDuration: 250,
+  loadedLatencyMaxPoints: 20
+};
+
+function createCalc(configOverrides = {}) {
+  return new MeasurementCalculations({
+    ...defaultCalcConfig,
+    ...configOverrides
+  });
+}
+
+describe('MeasurementCalculations', () => {
+  describe('getLatencyPoints', () => {
+    it('extracts ping values from timings', () => {
+      const calc = createCalc();
+      const result = calc.getLatencyPoints({
+        timings: [{ ping: 10 }, { ping: 20 }, { ping: 30 }]
+      });
+      expect(result).toEqual([10, 20, 30]);
+    });
+
+    it('returns empty array for empty timings', () => {
+      const calc = createCalc();
+      expect(calc.getLatencyPoints({ timings: [] })).toEqual([]);
+    });
+  });
+
+  describe('getLatency', () => {
+    it('returns the median ping (p50) by default', () => {
+      const calc = createCalc();
+      const result = calc.getLatency({
+        timings: [{ ping: 10 }, { ping: 20 }, { ping: 30 }]
+      });
+      expect(result).toBe(20);
+    });
+
+    it('uses configured percentile', () => {
+      const calc = createCalc({ latencyPercentile: 0 });
+      const result = calc.getLatency({
+        timings: [{ ping: 10 }, { ping: 20 }, { ping: 30 }]
+      });
+      expect(result).toBe(10); // p0 = minimum
+    });
+  });
+
+  describe('getJitter', () => {
+    it('calculates average delta between consecutive pings', () => {
+      const calc = createCalc();
+      // deltas: |20-10|=10, |30-20|=10 => avg = 10
+      const result = calc.getJitter({
+        timings: [{ ping: 10 }, { ping: 20 }, { ping: 30 }]
+      });
+      expect(result).toBe(10);
+    });
+
+    it('returns null for a single ping', () => {
+      const calc = createCalc();
+      expect(calc.getJitter({ timings: [{ ping: 10 }] })).toBeNull();
+    });
+
+    it('returns null for empty timings', () => {
+      const calc = createCalc();
+      expect(calc.getJitter({ timings: [] })).toBeNull();
+    });
+
+    it('handles variable deltas', () => {
+      const calc = createCalc();
+      // deltas: |15-10|=5, |25-15|=10, |20-25|=5 => avg = 20/3
+      const result = calc.getJitter({
+        timings: [{ ping: 10 }, { ping: 15 }, { ping: 25 }, { ping: 20 }]
+      });
+      expect(result).toBeCloseTo(20 / 3);
+    });
+  });
+
+  describe('getBandwidthPoints', () => {
+    it('flattens bandwidth results from all byte sizes', () => {
+      const calc = createCalc();
+      const result = calc.getBandwidthPoints({
+        100000: {
+          timings: [
+            {
+              bps: 1e6,
+              duration: 50,
+              ping: 10,
+              measTime: 100,
+              serverTime: 5,
+              transferSize: 100000
+            }
+          ]
+        },
+        1000000: {
+          timings: [
+            {
+              bps: 10e6,
+              duration: 100,
+              ping: 12,
+              measTime: 200,
+              serverTime: 8,
+              transferSize: 1000000
+            }
+          ]
+        }
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].bytes).toBe(100000);
+      expect(result[1].bytes).toBe(1000000);
+    });
+  });
+
+  describe('getBandwidth', () => {
+    it('filters by minimum request duration and returns p90', () => {
+      const calc = createCalc({
+        bandwidthMinRequestDuration: 10,
+        bandwidthPercentile: 0.9
+      });
+
+      const result = calc.getBandwidth({
+        100000: {
+          timings: [
+            {
+              bps: 1e6,
+              duration: 5,
+              ping: 10,
+              measTime: 100,
+              serverTime: 5,
+              transferSize: 100000
+            }, // filtered out (duration < 10)
+            {
+              bps: 5e6,
+              duration: 50,
+              ping: 10,
+              measTime: 100,
+              serverTime: 5,
+              transferSize: 100000
+            },
+            {
+              bps: 10e6,
+              duration: 100,
+              ping: 10,
+              measTime: 100,
+              serverTime: 5,
+              transferSize: 100000
+            }
+          ]
+        }
+      });
+
+      // Only bps values with duration >= 10: [5e6, 10e6]
+      // p90 of [5e6, 10e6]: idx = 1 * 0.9 = 0.9, edges = [5e6, 10e6]
+      // result = 5e6 + (10e6 - 5e6) * 0.9 = 9.5e6
+      expect(result).toBeCloseTo(9.5e6);
+    });
+  });
+
+  describe('getPacketLoss', () => {
+    it('returns the packetLoss value directly', () => {
+      const calc = createCalc();
+      expect(calc.getPacketLoss({ packetLoss: 0.02 })).toBe(0.02);
+    });
+  });
+
+  describe('getPacketLossDetails', () => {
+    it('returns the full results object', () => {
+      const calc = createCalc();
+      const details = {
+        packetLoss: 0.02,
+        totalMessages: 100,
+        numMessagesSent: 100,
+        lostMessages: [5, 10]
+      };
+      expect(calc.getPacketLossDetails(details)).toBe(details);
+    });
+  });
+
+  describe('getLoadedLatency', () => {
+    it('extracts side latency from loaded results', () => {
+      const calc = createCalc({
+        loadedRequestMinDuration: 100,
+        loadedLatencyMaxPoints: 20,
+        latencyPercentile: 0.5
+      });
+
+      const result = calc.getLoadedLatency({
+        100000: {
+          timings: [{ duration: 200 }], // >= minDuration
+          sideLatency: [{ ping: 50 }, { ping: 60 }]
+        }
+      });
+
+      expect(result).toBe(55); // median of [50, 60]
+    });
+
+    it('filters out file sizes that did not saturate the connection', () => {
+      const calc = createCalc({
+        loadedRequestMinDuration: 250,
+        loadedLatencyMaxPoints: 20,
+        latencyPercentile: 0.5
+      });
+
+      const result = calc.getLoadedLatency({
+        100000: {
+          timings: [{ duration: 50 }], // < 250, filtered out
+          sideLatency: [{ ping: 999 }]
+        },
+        1000000: {
+          timings: [{ duration: 300 }], // >= 250, kept
+          sideLatency: [{ ping: 40 }, { ping: 60 }]
+        }
+      });
+
+      expect(result).toBe(50); // median of [40, 60] from the 1M size only
+    });
+  });
+
+  describe('getReachability', () => {
+    it('returns true for reachable results', () => {
+      const calc = createCalc();
+      expect(calc.getReachability({ reachable: true })).toBe(true);
+    });
+
+    it('returns false for unreachable results', () => {
+      const calc = createCalc();
+      expect(calc.getReachability({ reachable: false })).toBe(false);
+    });
+  });
+});

--- a/tests/unit/Results/Results.test.ts
+++ b/tests/unit/Results/Results.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import Results from '../../../src/Results/index.js';
+import defaultConfig from '../../../src/config/defaultConfig.js';
+import internalConfig from '../../../src/config/internalConfig.js';
+
+function createResults(configOverrides = {}) {
+  return new Results({
+    ...defaultConfig,
+    ...internalConfig,
+    ...configOverrides
+  });
+}
+
+describe('Results', () => {
+  describe('constructor and clear', () => {
+    it('initializes raw results with measurement types from config', () => {
+      const results = createResults();
+      expect(results.raw).toHaveProperty('latency');
+      expect(results.raw).toHaveProperty('download');
+      expect(results.raw).toHaveProperty('upload');
+      expect(results.raw).toHaveProperty('packetLoss');
+      expect(results.raw).toHaveProperty('totalDurationMs');
+    });
+
+    it('marks all measurements as not started and not finished', () => {
+      const results = createResults();
+      for (const key of ['latency', 'download', 'upload', 'packetLoss']) {
+        expect(results.raw[key].started).toBe(false);
+        expect(results.raw[key].finished).toBe(false);
+      }
+    });
+
+    it('clears results back to initial state', () => {
+      const results = createResults();
+      results.raw.latency.started = true;
+      results.raw.latency.finished = true;
+      results.clear();
+      expect(results.raw.latency.started).toBe(false);
+      expect(results.raw.latency.finished).toBe(false);
+    });
+  });
+
+  describe('isFinished', () => {
+    it('returns false when no measurements have finished', () => {
+      const results = createResults();
+      expect(results.isFinished).toBe(false);
+    });
+
+    it('returns true when all measurements are finished', () => {
+      const results = createResults({
+        measurements: [{ type: 'latency', numPackets: 1 }]
+      });
+      results.raw.latency.finished = true;
+      expect(results.isFinished).toBe(true);
+    });
+
+    it('returns false when only some measurements are finished', () => {
+      const results = createResults({
+        measurements: [
+          { type: 'latency', numPackets: 1 },
+          { type: 'download', bytes: 1e5, count: 1 }
+        ]
+      });
+      results.raw.latency.finished = true;
+      results.raw.download.finished = false;
+      expect(results.isFinished).toBe(false);
+    });
+  });
+
+  describe('getters return undefined when measurement not started', () => {
+    it('getUnloadedLatency returns undefined', () => {
+      const results = createResults();
+      expect(results.getUnloadedLatency()).toBeUndefined();
+    });
+
+    it('getDownloadBandwidth returns undefined', () => {
+      const results = createResults();
+      expect(results.getDownloadBandwidth()).toBeUndefined();
+    });
+
+    it('getPacketLoss returns undefined', () => {
+      const results = createResults();
+      expect(results.getPacketLoss()).toBeUndefined();
+    });
+
+    it('getUnloadedLatencyPoints returns empty array', () => {
+      const results = createResults();
+      expect(results.getUnloadedLatencyPoints()).toEqual([]);
+    });
+  });
+
+  describe('getters with populated data', () => {
+    it('returns latency when measurement is started', () => {
+      const results = createResults();
+      results.raw.latency.started = true;
+      results.raw.latency.results = {
+        timings: [{ ping: 10 }, { ping: 20 }, { ping: 30 }]
+      };
+      expect(results.getUnloadedLatency()).toBe(20); // median
+    });
+
+    it('returns jitter when measurement is started', () => {
+      const results = createResults();
+      results.raw.latency.started = true;
+      results.raw.latency.results = {
+        timings: [{ ping: 10 }, { ping: 20 }, { ping: 30 }]
+      };
+      expect(results.getUnloadedJitter()).toBe(10);
+    });
+
+    it('returns bandwidth when measurement is started', () => {
+      const results = createResults();
+      results.raw.download.started = true;
+      results.raw.download.results = {
+        100000: {
+          timings: [
+            {
+              bps: 10e6,
+              duration: 50,
+              ping: 10,
+              measTime: 100,
+              serverTime: 5,
+              transferSize: 100000
+            }
+          ]
+        }
+      };
+      expect(results.getDownloadBandwidth()).toBe(10e6);
+    });
+
+    it('returns packet loss details with error when error exists', () => {
+      const results = createResults();
+      results.raw.packetLoss.started = true;
+      results.raw.packetLoss.error = 'Connection failed';
+      const details = results.getPacketLossDetails();
+      expect(details).toEqual({ error: 'Connection failed' });
+    });
+  });
+
+  describe('getSummary', () => {
+    it('returns empty object when nothing is started', () => {
+      const results = createResults();
+      const summary = results.getSummary();
+      // Only totalDurationMs might be undefined, so it's excluded
+      expect(Object.keys(summary)).toHaveLength(0);
+    });
+
+    it('includes only started measurements in summary', () => {
+      const results = createResults();
+      results.raw.latency.started = true;
+      results.raw.latency.results = {
+        timings: [{ ping: 15 }]
+      };
+
+      const summary = results.getSummary();
+      expect(summary).toHaveProperty('latency');
+      expect(summary.latency).toBe(15);
+      expect(summary).not.toHaveProperty('download');
+      expect(summary).not.toHaveProperty('upload');
+    });
+
+    it('includes totalDurationMs when set', () => {
+      const results = createResults();
+      results.raw.totalDurationMs = 5000;
+      const summary = results.getSummary();
+      expect(summary.totalDurationMs).toBe(5000);
+    });
+  });
+
+  describe('getScores', () => {
+    it('returns scores based on current summary', () => {
+      const results = createResults();
+      results.raw.latency.started = true;
+      results.raw.latency.results = {
+        timings: [{ ping: 5 }]
+      };
+      results.raw.download.started = true;
+      results.raw.download.results = {
+        100000: {
+          timings: [
+            {
+              bps: 100e6,
+              duration: 50,
+              ping: 5,
+              measTime: 100,
+              serverTime: 2,
+              transferSize: 100000
+            }
+          ],
+          sideLatency: [{ ping: 10 }, { ping: 15 }]
+        }
+      };
+
+      const scores = results.getScores();
+      expect(typeof scores).toBe('object');
+    });
+  });
+});

--- a/tests/unit/Results/ScoresCalculations.test.ts
+++ b/tests/unit/Results/ScoresCalculations.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import ScoresCalculations from '../../../src/Results/ScoresCalculations.js';
+import internalConfig from '../../../src/config/internalConfig.js';
+
+function createScoresCalc() {
+  return new ScoresCalculations(internalConfig);
+}
+
+describe('ScoresCalculations', () => {
+  describe('getScores', () => {
+    it('returns empty object when no measurements available', () => {
+      const calc = createScoresCalc();
+      const scores = calc.getScores({});
+      expect(scores).toEqual({});
+    });
+
+    it('calculates streaming score for excellent connection', () => {
+      const calc = createScoresCalc();
+      const scores = calc.getScores({
+        latency: 5, // 20 points
+        packetLoss: 0, // 10 points
+        download: 100e6, // 30 points
+        downLoadedLatency: 15, // loadedLatencyIncrease = 15 - 5 = 10 => 10 points
+        upLoadedLatency: 10
+      });
+
+      expect(scores.streaming).toBeDefined();
+      expect(scores.streaming.classificationName).toBe('great');
+      expect(scores.streaming.classificationIdx).toBe(4);
+      expect(scores.streaming.points).toBeGreaterThan(0);
+    });
+
+    it('calculates gaming score for poor connection', () => {
+      const calc = createScoresCalc();
+      const scores = calc.getScores({
+        latency: 200, // -10 points
+        packetLoss: 0.3, // -10 points
+        downLoadedLatency: 500, // loadedLatencyIncrease = 500 - 200 = 300 => -10 points
+        upLoadedLatency: 400
+      });
+
+      expect(scores.gaming).toBeDefined();
+      // All negative points => clamped to 0
+      expect(scores.gaming.points).toBe(0);
+      expect(scores.gaming.classificationName).toBe('bad');
+      expect(scores.gaming.classificationIdx).toBe(0);
+    });
+
+    it('skips experiences when required inputs are missing', () => {
+      const calc = createScoresCalc();
+      // Only provide latency — not enough for any experience
+      const scores = calc.getScores({
+        latency: 10
+      });
+
+      // packetLoss defaults to 0, but loadedLatencyIncrease needs
+      // both latency and loaded latency
+      expect(scores.streaming).toBeUndefined();
+      expect(scores.gaming).toBeUndefined();
+      expect(scores.rtc).toBeUndefined();
+    });
+
+    it('calculates all three experience scores', () => {
+      const calc = createScoresCalc();
+      const scores = calc.getScores({
+        latency: 20,
+        jitter: 10,
+        packetLoss: 0.01,
+        download: 50e6,
+        upload: 10e6,
+        downLoadedLatency: 50,
+        upLoadedLatency: 40
+      });
+
+      expect(scores.streaming).toBeDefined();
+      expect(scores.gaming).toBeDefined();
+      expect(scores.rtc).toBeDefined();
+
+      // Each should have the required properties
+      for (const experience of ['streaming', 'gaming', 'rtc']) {
+        expect(scores[experience]).toHaveProperty('points');
+        expect(scores[experience]).toHaveProperty('classificationIdx');
+        expect(scores[experience]).toHaveProperty('classificationName');
+        expect(scores[experience].classificationIdx).toBeGreaterThanOrEqual(0);
+        expect(scores[experience].classificationIdx).toBeLessThanOrEqual(4);
+        expect(
+          ['bad', 'poor', 'average', 'good', 'great'].includes(
+            scores[experience].classificationName
+          )
+        ).toBe(true);
+      }
+    });
+
+    it('uses default points for packetLoss when not provided', () => {
+      const calc = createScoresCalc();
+      // packetLoss defaults to 0 points when missing
+      const scores = calc.getScores({
+        latency: 5,
+        download: 100e6,
+        downLoadedLatency: 10,
+        upLoadedLatency: 8
+      });
+
+      // Streaming should work: latency (20) + packetLoss (0 default)
+      // + download (30) + loadedLatencyIncrease (10-5=5 => 20 points)
+      expect(scores.streaming).toBeDefined();
+    });
+  });
+});

--- a/tests/unit/config/defaultConfig.test.ts
+++ b/tests/unit/config/defaultConfig.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import defaultConfig from '../../../src/config/defaultConfig.js';
+
+describe('defaultConfig', () => {
+  it('has autoStart enabled by default', () => {
+    expect(defaultConfig.autoStart).toBe(true);
+  });
+
+  it('has correct API URLs', () => {
+    expect(defaultConfig.downloadApiUrl).toBe(
+      'https://speed.cloudflare.com/__down'
+    );
+    expect(defaultConfig.uploadApiUrl).toBe(
+      'https://speed.cloudflare.com/__up'
+    );
+    expect(defaultConfig.turnServerCredsApiUrl).toBe(
+      'https://speed.cloudflare.com/turn-creds'
+    );
+  });
+
+  it('has a measurements array with expected types', () => {
+    expect(Array.isArray(defaultConfig.measurements)).toBe(true);
+    expect(defaultConfig.measurements.length).toBeGreaterThan(0);
+
+    const types = new Set(defaultConfig.measurements.map(m => m.type));
+    expect(types).toContain('latency');
+    expect(types).toContain('download');
+    expect(types).toContain('upload');
+    expect(types).toContain('packetLoss');
+  });
+
+  it('has valid percentile values between 0 and 1', () => {
+    expect(defaultConfig.latencyPercentile).toBeGreaterThanOrEqual(0);
+    expect(defaultConfig.latencyPercentile).toBeLessThanOrEqual(1);
+    expect(defaultConfig.bandwidthPercentile).toBeGreaterThanOrEqual(0);
+    expect(defaultConfig.bandwidthPercentile).toBeLessThanOrEqual(1);
+  });
+
+  it('has positive duration thresholds', () => {
+    expect(defaultConfig.bandwidthFinishRequestDuration).toBeGreaterThan(0);
+    expect(defaultConfig.bandwidthMinRequestDuration).toBeGreaterThan(0);
+    expect(defaultConfig.loadedRequestMinDuration).toBeGreaterThan(0);
+    expect(defaultConfig.loadedLatencyMaxPoints).toBeGreaterThan(0);
+  });
+
+  it('has loaded latency measurement flags', () => {
+    expect(defaultConfig.measureDownloadLoadedLatency).toBe(true);
+    expect(defaultConfig.measureUploadLoadedLatency).toBe(true);
+  });
+
+  it('has credentials disabled by default', () => {
+    expect(defaultConfig.includeCredentials).toBe(false);
+  });
+
+  it('has null values for optional TURN server credentials', () => {
+    expect(defaultConfig.turnServerUser).toBeNull();
+    expect(defaultConfig.turnServerPass).toBeNull();
+  });
+});

--- a/tests/unit/config/internalConfig.test.ts
+++ b/tests/unit/config/internalConfig.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import internalConfig from '../../../src/config/internalConfig.js';
+
+describe('internalConfig', () => {
+  describe('aimMeasurementScoring', () => {
+    const { aimMeasurementScoring } = internalConfig;
+
+    it('has scoring functions for all measurement types', () => {
+      const expectedTypes = [
+        'packetLoss',
+        'latency',
+        'loadedLatencyIncrease',
+        'jitter',
+        'download',
+        'upload'
+      ];
+      for (const type of expectedTypes) {
+        expect(typeof aimMeasurementScoring[type]).toBe('function');
+      }
+    });
+
+    it('scores packetLoss correctly', () => {
+      const score = aimMeasurementScoring.packetLoss;
+      expect(score(0)).toBe(10); // 0% loss = best
+      expect(score(0.01)).toBe(5); // at first threshold
+      expect(score(0.5)).toBe(-20); // 50% loss = worst
+    });
+
+    it('scores latency correctly', () => {
+      const score = aimMeasurementScoring.latency;
+      expect(score(5)).toBe(20); // excellent latency
+      expect(score(10)).toBe(10); // at first threshold
+      expect(score(50)).toBe(0); // at third threshold
+      expect(score(500)).toBe(-20); // very high latency
+    });
+
+    it('scores download bandwidth correctly', () => {
+      const score = aimMeasurementScoring.download;
+      expect(score(0)).toBe(0); // no bandwidth
+      expect(score(1e6)).toBe(5); // 1 Mbps
+      expect(score(100e6)).toBe(30); // 100 Mbps = max points
+    });
+
+    it('scores upload bandwidth correctly', () => {
+      const score = aimMeasurementScoring.upload;
+      expect(score(0)).toBe(0);
+      expect(score(50e6)).toBe(20);
+      expect(score(100e6)).toBe(30);
+    });
+  });
+
+  describe('aimExperiencesDefs', () => {
+    const { aimExperiencesDefs } = internalConfig;
+
+    it('defines streaming, gaming, and rtc experiences', () => {
+      expect(aimExperiencesDefs).toHaveProperty('streaming');
+      expect(aimExperiencesDefs).toHaveProperty('gaming');
+      expect(aimExperiencesDefs).toHaveProperty('rtc');
+    });
+
+    it('streaming depends on latency, packetLoss, download, and loadedLatencyIncrease', () => {
+      expect(aimExperiencesDefs.streaming.input).toEqual([
+        'latency',
+        'packetLoss',
+        'download',
+        'loadedLatencyIncrease'
+      ]);
+    });
+
+    it('has ascending point thresholds for each experience', () => {
+      for (const [, def] of Object.entries(aimExperiencesDefs)) {
+        for (let i = 1; i < def.pointThresholds.length; i++) {
+          expect(def.pointThresholds[i]).toBeGreaterThan(
+            def.pointThresholds[i - 1]
+          );
+        }
+      }
+    });
+  });
+});

--- a/tests/unit/utils/numbers.test.ts
+++ b/tests/unit/utils/numbers.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { sum, avg, percentile } from '../../../src/utils/numbers.js';
+
+describe('sum', () => {
+  it('sums an array of numbers', () => {
+    expect(sum([1, 2, 3])).toBe(6);
+  });
+
+  it('returns 0 for an empty array', () => {
+    expect(sum([])).toBe(0);
+  });
+
+  it('handles a single element', () => {
+    expect(sum([42])).toBe(42);
+  });
+
+  it('handles negative numbers', () => {
+    expect(sum([-1, 1, -2, 2])).toBe(0);
+  });
+
+  it('handles floating point numbers', () => {
+    expect(sum([0.1, 0.2])).toBeCloseTo(0.3);
+  });
+});
+
+describe('avg', () => {
+  it('calculates the average', () => {
+    expect(avg([2, 4, 6])).toBe(4);
+  });
+
+  it('returns NaN for an empty array', () => {
+    expect(avg([])).toBeNaN();
+  });
+
+  it('returns the value for a single element', () => {
+    expect(avg([10])).toBe(10);
+  });
+
+  it('handles floating point results', () => {
+    expect(avg([1, 2])).toBe(1.5);
+  });
+});
+
+describe('percentile', () => {
+  it('returns 0 for an empty array', () => {
+    expect(percentile([])).toBe(0);
+  });
+
+  it('returns the single value for a one-element array', () => {
+    expect(percentile([42])).toBe(42);
+    expect(percentile([42], 0)).toBe(42);
+    expect(percentile([42], 1)).toBe(42);
+  });
+
+  it('calculates the median (default p50)', () => {
+    expect(percentile([1, 2, 3, 4, 5])).toBe(3);
+  });
+
+  it('calculates p0 (minimum)', () => {
+    expect(percentile([10, 20, 30], 0)).toBe(10);
+  });
+
+  it('calculates p100 (maximum)', () => {
+    expect(percentile([10, 20, 30], 1)).toBe(30);
+  });
+
+  it('calculates p90', () => {
+    // For [1, 2, 3, 4, 5], idx = 4 * 0.9 = 3.6
+    // floor=3 (val=4), ceil=4 (val=5), rem=0.6
+    // result = 4 + (5 - 4) * 0.6 = 4.6
+    expect(percentile([1, 2, 3, 4, 5], 0.9)).toBeCloseTo(4.6);
+  });
+
+  it('sorts the input without mutating the original array', () => {
+    const input = [5, 1, 3, 2, 4];
+    const copy = [...input];
+    percentile(input, 0.5);
+    expect(input).toEqual(copy);
+  });
+
+  it('handles unsorted input', () => {
+    expect(percentile([5, 1, 3], 0.5)).toBe(3);
+  });
+
+  it('handles duplicate values', () => {
+    expect(percentile([5, 5, 5, 5], 0.5)).toBe(5);
+  });
+});

--- a/tests/unit/utils/scaleThreshold.test.ts
+++ b/tests/unit/utils/scaleThreshold.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import scaleThreshold from '../../../src/utils/scaleThreshold.js';
+
+describe('scaleThreshold', () => {
+  it('returns range[0] for values below the first threshold', () => {
+    const scale = scaleThreshold([10, 20, 30], ['a', 'b', 'c', 'd']);
+    expect(scale(5)).toBe('a');
+  });
+
+  it('returns the correct range value for values at thresholds', () => {
+    const scale = scaleThreshold([10, 20, 30], ['a', 'b', 'c', 'd']);
+    // value >= 10, so moves past first threshold
+    expect(scale(10)).toBe('b');
+    expect(scale(20)).toBe('c');
+    expect(scale(30)).toBe('d');
+  });
+
+  it('returns the last range value for values above all thresholds', () => {
+    const scale = scaleThreshold([10, 20], ['low', 'mid', 'high']);
+    expect(scale(100)).toBe('high');
+  });
+
+  it('returns range[0] for NaN', () => {
+    const scale = scaleThreshold([10, 20], ['a', 'b', 'c']);
+    expect(scale(NaN)).toBe('a');
+  });
+
+  it('returns range[0] for null', () => {
+    const scale = scaleThreshold([10, 20], ['a', 'b', 'c']);
+    expect(scale(null)).toBe('a');
+  });
+
+  it('returns range[0] for undefined', () => {
+    const scale = scaleThreshold([10, 20], ['a', 'b', 'c']);
+    expect(scale(undefined)).toBe('a');
+  });
+
+  it('works with numeric ranges', () => {
+    const scale = scaleThreshold([0.01, 0.05, 0.25, 0.5], [10, 5, 0, -10, -20]);
+    expect(scale(0)).toBe(10); // below all thresholds
+    expect(scale(0.01)).toBe(5); // at first threshold
+    expect(scale(0.03)).toBe(5); // between first and second
+    expect(scale(0.5)).toBe(-20); // at last threshold
+    expect(scale(1)).toBe(-20); // above all thresholds
+  });
+
+  it('handles a single threshold', () => {
+    const scale = scaleThreshold([50], ['below', 'above']);
+    expect(scale(49)).toBe('below');
+    expect(scale(50)).toBe('above');
+    expect(scale(51)).toBe('above');
+  });
+
+  it('handles empty domain (always returns range[0])', () => {
+    const scale = scaleThreshold([], ['only']);
+    expect(scale(0)).toBe('only');
+    expect(scale(100)).toBe('only');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['tests/unit/**/*.test.ts'],
+          environment: 'node'
+        }
+      },
+      {
+        test: {
+          name: 'e2e',
+          include: ['tests/e2e/**/*.test.ts'],
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [{ browser: 'chromium' }]
+          }
+        }
+      }
+    ]
+  }
+});


### PR DESCRIPTION
## Summary

Add a test suite using [Vitest](https://vitest.dev/) with two test projects: unit tests (Node) and e2e tests (Playwright + Chromium).

## Test coverage

### Unit tests (83 tests, ~200ms)

Pure function tests with no browser dependencies:

| Module | Tests | What's covered |
|--------|-------|---------------|
| `utils/numbers` | 18 | `sum`, `avg`, `percentile` — edge cases, empty arrays, interpolation, immutability |
| `utils/scaleThreshold` | 9 | Threshold mapping, boundary values, NaN/null/undefined handling |
| `config/defaultConfig` | 8 | Structure validation, API URLs, percentile ranges, duration thresholds |
| `config/internalConfig` | 8 | AIM scoring functions (packetLoss, latency, bandwidth), experience definitions |
| `Results/MeasurementCalculations` | 16 | Latency, jitter, bandwidth, loaded latency, packet loss calculations with fixture data |
| `Results/ScoresCalculations` | 6 | AIM experience scoring (streaming/gaming/rtc), classification names |
| `Results/Results` | 18 | Full Results class: `getSummary()`, `getScores()`, all getters, `isFinished`, error handling |

### E2E test (1 test, ~500ms)

Runs a minimal speed test in a real headless Chromium browser via Vitest Browser Mode + Playwright:
- Configures a short test (3 latency packets + 1 small download)
- Validates that latency, jitter, download, and totalDurationMs are present and numeric
- Tests the full integration: module loading, fetch, PerformanceResourceTiming, result aggregation
- Retries up to 2 times to handle transient network issues

## Changes

### Added
- `vitest.config.ts` — Vitest config with `unit` (Node) and `e2e` (Playwright/Chromium) projects
- `tests/unit/` — 7 unit test files mirroring `src/` structure
- `tests/e2e/speedtest.test.ts` — e2e smoke test

### Modified
- `package.json` — added `test`, `test:unit`, `test:e2e`, `test:watch` scripts; added `vitest`, `@vitest/browser-playwright`, `playwright` devDependencies
- `.github/workflows/build.yml` — added unit test, Playwright install (`--with-deps`), and e2e test steps to CI
- `.gitignore` — added Playwright/Vitest artifact patterns (`test-results/`, `playwright-report/`, `coverage/`, etc.)
- `AGENTS.md` — documented test commands and test structure

## Notes

- Test files are TypeScript (`.test.ts`) as a stepping stone for the planned JS → TS migration, while source remains JS
- E2E test uses a minimal config (`{ type: 'latency', numPackets: 3 }` + one small download) to keep runtime ~500ms
- E2E test skips packet loss (TURN credentials require `speed.cloudflare.com` origin due to CORS)
- E2E test has `retry: 2` to handle transient network failures in CI
- CI installs Chromium via `npx playwright install --with-deps chromium` (includes system libraries for Ubuntu)