### PR TITLE
fix: prevent double '?' when custom apiUrl already contains query string

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -262,7 +262,7 @@ class BandwidthMeasurementEngine {
       apiUrl.startsWith('http') || apiUrl.startsWith('//')
         ? ''
         : window.location.origin // use abs to match perf timing urls
-    }${apiUrl}?${Object.entries(qsParams)
+    }${apiUrl}${apiUrl.includes('?') ? '&' : '?'}${Object.entries(qsParams)
       .map(([k, v]) => `${k}=${v}`)
       .join('&')}`;
 

--- a/src/engines/LoadNetworkEngine/index.js
+++ b/src/engines/LoadNetworkEngine/index.js
@@ -71,7 +71,7 @@ class LoadNetworkEngine {
           apiUrl.startsWith('http') || apiUrl.startsWith('//')
             ? ''
             : window.location.origin // use abs to match perf timing urls
-        }${apiUrl}?${Object.entries(fetchQsParams)
+        }${apiUrl}${apiUrl.includes('?') ? '&' : '?'}${Object.entries(fetchQsParams)
           .map(([k, v]) => `${k}=${v}`)
           .join('&')}`;
         const fetchOpt = Object.assign({}, fetchOptions, this.fetchOptions);


### PR DESCRIPTION
Fixes #105

## Summary
When `downloadApiUrl` or `uploadApiUrl` already contain a query string (e.g., `?token=***`), the engine appends its own params with a literal `?` separator, producing a malformed URL with two `?` characters.

## Changes
- `BandwidthEngine.js`: Check if `apiUrl` already contains `?` — use `&` as separator if so, otherwise use `?`
- `LoadNetworkEngine/index.js`: Same fix for the fetch URL construction

## Testing
- URLs without existing query strings still work as before (`?bytes=...`)
- URLs with existing query strings now correctly append with `&` (e.g., `?token=***&bytes=...`)