### PR TITLE
fix: use URL API for query string construction

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,13 @@ export default [
     },
     settings: {
       // Polyfills for compat plugin
-      polyfills: ['Array.prototype.includes', 'Promise', 'fetch']
+      polyfills: [
+        'Array.prototype.includes',
+        'Promise',
+        'fetch',
+        'URL',
+        'URLSearchParams'
+      ]
     }
   }
 ];

--- a/src/engines/BandwidthEngine/BandwidthEngine.js
+++ b/src/engines/BandwidthEngine/BandwidthEngine.js
@@ -258,13 +258,9 @@ class BandwidthMeasurementEngine {
     const qsParams = Object.assign({}, this.#qsParams);
     isDown && (qsParams.bytes = `${numBytes}`);
 
-    const url = `${
-      apiUrl.startsWith('http') || apiUrl.startsWith('//')
-        ? ''
-        : window.location.origin // use abs to match perf timing urls
-    }${apiUrl}?${Object.entries(qsParams)
-      .map(([k, v]) => `${k}=${v}`)
-      .join('&')}`;
+    const urlObj = new URL(apiUrl, window.location.origin);
+    Object.entries(qsParams).forEach(([k, v]) => urlObj.searchParams.set(k, v));
+    const url = urlObj.href;
 
     const fetchOpt = Object.assign(
       {},

--- a/src/engines/LoadNetworkEngine/index.js
+++ b/src/engines/LoadNetworkEngine/index.js
@@ -67,13 +67,11 @@ class LoadNetworkEngine {
     const getLoadEngine = ({ apiUrl, qsParams = {}, fetchOptions = {} }) =>
       new PromiseEngine(() => {
         const fetchQsParams = Object.assign({}, qsParams, this.qsParams);
-        const url = `${
-          apiUrl.startsWith('http') || apiUrl.startsWith('//')
-            ? ''
-            : window.location.origin // use abs to match perf timing urls
-        }${apiUrl}?${Object.entries(fetchQsParams)
-          .map(([k, v]) => `${k}=${v}`)
-          .join('&')}`;
+        const urlObj = new URL(apiUrl, window.location.origin);
+        Object.entries(fetchQsParams).forEach(([k, v]) =>
+          urlObj.searchParams.set(k, v)
+        );
+        const url = urlObj.href;
         const fetchOpt = Object.assign({}, fetchOptions, this.fetchOptions);
 
         return fetch(url, fetchOpt)

--- a/tests/unit/engines/urlConstruction.test.ts
+++ b/tests/unit/engines/urlConstruction.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for the URL construction pattern used in BandwidthEngine and
+ * LoadNetworkEngine. Both engines build URLs using the URL API:
+ *
+ *   const urlObj = new URL(apiUrl, window.location.origin);
+ *   Object.entries(qsParams).forEach(([k, v]) => urlObj.searchParams.set(k, v));
+ *   const url = urlObj.href;
+ *
+ * This ensures custom apiUrls with existing query strings (e.g.,
+ * `?token=ABC`) are handled correctly without double-? issues.
+ *
+ * See: https://github.com/cloudflare/speedtest/issues/105
+ */
+
+const ORIGIN = 'https://localhost';
+
+function buildUrl(
+  apiUrl: string,
+  qsParams: Record<string, string>
+): string {
+  const urlObj = new URL(apiUrl, ORIGIN);
+  Object.entries(qsParams).forEach(([k, v]) =>
+    urlObj.searchParams.set(k, v)
+  );
+  return urlObj.href;
+}
+
+describe('URL construction', () => {
+  describe('query string handling', () => {
+    it('appends params to URL without query string', () => {
+      const url = buildUrl('https://speed.cloudflare.com/__down', {
+        bytes: '100000'
+      });
+      expect(url).toBe(
+        'https://speed.cloudflare.com/__down?bytes=100000'
+      );
+    });
+
+    it('appends params to URL with existing query string', () => {
+      const url = buildUrl('https://example.com/__down?token=ABC', {
+        bytes: '100000'
+      });
+      expect(url).toBe(
+        'https://example.com/__down?token=ABC&bytes=100000'
+      );
+    });
+
+    it('preserves multiple existing params in apiUrl', () => {
+      const url = buildUrl(
+        'https://example.com/__down?token=ABC&region=us',
+        { bytes: '100000', measId: '42' }
+      );
+      expect(url).toBe(
+        'https://example.com/__down?token=ABC&region=us&bytes=100000&measId=42'
+      );
+    });
+
+    it('handles relative apiUrl without query string', () => {
+      const url = buildUrl('/__down', { bytes: '100000' });
+      expect(url).toBe(`${ORIGIN}/__down?bytes=100000`);
+    });
+
+    it('handles relative apiUrl with query string', () => {
+      const url = buildUrl('/__down?token=ABC', { bytes: '100000' });
+      expect(url).toBe(`${ORIGIN}/__down?token=ABC&bytes=100000`);
+    });
+
+    it('handles protocol-relative URLs', () => {
+      const url = buildUrl('//cdn.example.com/__down', {
+        bytes: '100000'
+      });
+      expect(url).toBe('https://cdn.example.com/__down?bytes=100000');
+    });
+
+    it('appends multiple query params', () => {
+      const url = buildUrl('https://speed.cloudflare.com/__down', {
+        bytes: '100000',
+        measId: '42',
+        during: 'download'
+      });
+      expect(url).toBe(
+        'https://speed.cloudflare.com/__down?bytes=100000&measId=42&during=download'
+      );
+    });
+
+    it('produces valid URL with empty qsParams', () => {
+      const url = buildUrl('https://speed.cloudflare.com/__down', {});
+      expect(url).toBe('https://speed.cloudflare.com/__down');
+    });
+  });
+
+  describe('URL encoding', () => {
+    it('encodes special characters in param values', () => {
+      const url = buildUrl('https://speed.cloudflare.com/__down', {
+        token: 'a&b=c'
+      });
+      expect(url).toContain('token=a%26b%3Dc');
+    });
+
+    it('encodes spaces in param values', () => {
+      const url = buildUrl('https://speed.cloudflare.com/__down', {
+        name: 'hello world'
+      });
+      expect(url).toContain('name=hello+world');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #105

## Summary

Replace manual URL string concatenation with the `URL` and `URLSearchParams` APIs in BandwidthEngine and LoadNetworkEngine.

## Problem

When `downloadApiUrl` or `uploadApiUrl` already contain a query string (e.g., `?token=ABC`), the engine appended its own params with a hardcoded `?` separator, producing a malformed URL with two `?` characters:

```
Expected: https://example.com/api/down?token=ABC&bytes=100000
Actual:   https://example.com/api/down?token=ABC?bytes=100000
```

This corrupted existing query params and broke authentication for users proxying through endpoints with token-based auth.

## Solution

Replace the manual URL construction:

```js
// Before (manual string concatenation, buggy):
const url = \`\${
  apiUrl.startsWith('http') || apiUrl.startsWith('//')
    ? ''
    : window.location.origin
}\${apiUrl}?\${Object.entries(qsParams)
  .map(([k, v]) => \\\`\${k}=\${v}\\\`)
  .join('&')}\`;

// After (URL API, correct):
const urlObj = new URL(apiUrl, window.location.origin);
Object.entries(qsParams).forEach(([k, v]) => urlObj.searchParams.set(k, v));
const url = urlObj.href;
```

This fixes three issues at once:
1. **Double `?` bug** — `URLSearchParams` correctly appends to existing query strings
2. **Missing URL encoding** — `URLSearchParams.set()` encodes special characters automatically
3. **Manual origin detection** — `new URL(relative, base)` handles absolute, relative, and protocol-relative URLs natively

## Changes

- `src/engines/BandwidthEngine/BandwidthEngine.js` — replace URL construction with `URL` + `URLSearchParams`
- `src/engines/LoadNetworkEngine/index.js` — same fix
- `eslint.config.js` — add `URL` and `URLSearchParams` to compat polyfills (same browser support as `fetch`)
- `tests/unit/engines/urlConstruction.test.ts` — 10 new unit tests covering query string handling and URL encoding

## Testing

- URLs without existing query strings still work as before
- URLs with existing query strings correctly append with `&`
- Special characters in param values are properly encoded
- Relative and protocol-relative URLs are handled correctly
- `performance.getEntriesByName(url)` matching is preserved (same URL string used for both `fetch()` and lookup)