### PR TITLE
ci: add Bonk AI code review workflow

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       id-token: write
-      contents: write
+      contents: read
       issues: write
       pull-requests: write
     steps:

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -1,0 +1,45 @@
+name: Bonk
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bonk:
+    # Only run when an org member (OWNER/MEMBER) explicitly mentions Bonk.
+    # This prevents external contributors on this public repo from triggering runs.
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association) &&
+      (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Bonk
+        uses: ask-bonk/ask-bonk/github@main
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
+          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+        with:
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          variant: "high"
+          mentions: "/bonk,@ask-bonk"
+          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -13,51 +13,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Automatic review when a PR is opened. Internal (non-fork) PRs only, because
-  # GitHub does not expose the CF_AI_GATEWAY_* secrets to fork-triggered runs.
-  auto-review:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.sender.type != 'Bot' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      contents: read
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Run Bonk (auto review)
-        uses: ask-bonk/ask-bonk/github@main
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
-          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
-        with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
-          # Review-only: Bonk leaves comments/suggestions but never pushes commits.
-          permissions: write
-          token_permissions: NO_PUSH
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
-          prompt: |
-            Review this pull request. Summarize what it changes and flag any
-            correctness, security, or style issues as inline review comments.
-            Do not push commits.
-
-  # Manual review on demand: an org member comments /bonk or @ask-bonk.
   bonk:
+    # Runs in two situations:
+    #  - automatically when a PR is opened (internal PRs only; fork-triggered
+    #    runs don't receive the CF_AI_GATEWAY_* secrets), or
+    #  - on demand when an org member (OWNER/MEMBER) comments /bonk or @ask-bonk.
     if: >-
-      github.event_name != 'pull_request' &&
-      github.event.sender.type != 'Bot' &&
-      contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association) &&
-      (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk'))
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'pull_request' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name != 'pull_request' &&
+         contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association) &&
+         (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk')))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -81,8 +49,12 @@ jobs:
         with:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           mentions: "/bonk,@ask-bonk"
-          # Only users with write access may invoke Bonk.
+          # Only users with write access may invoke Bonk via comment.
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
           opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          prompt: |
+            Review this pull request. Summarize what it changes and flag any
+            correctness, security, or style issues as inline review comments.
+            Do not push commits.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -1,6 +1,8 @@
 name: Bonk
 
 on:
+  pull_request:
+    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -11,10 +13,48 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  bonk:
-    # Only run when an org member (OWNER/MEMBER) explicitly mentions Bonk.
-    # This prevents external contributors on this public repo from triggering runs.
+  # Automatic review when a PR is opened. Internal (non-fork) PRs only, because
+  # GitHub does not expose the CF_AI_GATEWAY_* secrets to fork-triggered runs.
+  auto-review:
     if: >-
+      github.event_name == 'pull_request' &&
+      github.event.sender.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Bonk (auto review)
+        uses: ask-bonk/ask-bonk/github@main
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
+          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+        with:
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          # Review-only: Bonk leaves comments/suggestions but never pushes commits.
+          permissions: write
+          token_permissions: NO_PUSH
+          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          prompt: |
+            Review this pull request. Summarize what it changes and flag any
+            correctness, security, or style issues as inline review comments.
+            Do not push commits.
+
+  # Manual review on demand: an org member comments /bonk or @ask-bonk.
+  bonk:
+    if: >-
+      github.event_name != 'pull_request' &&
       github.event.sender.type != 'Bot' &&
       contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association) &&
       (contains(github.event.comment.body, '/bonk') || contains(github.event.comment.body, '@ask-bonk'))

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -40,7 +40,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
-          variant: "high"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk.
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -42,4 +42,8 @@ jobs:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           variant: "high"
           mentions: "/bonk,@ask-bonk"
+          # Only users with write access may invoke Bonk.
+          permissions: write
+          # Review-only: Bonk leaves comments/suggestions but never pushes commits.
+          token_permissions: NO_PUSH
           opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues


### PR DESCRIPTION
Adds a `.github/workflows/bonk.yml` so we can use the Bonk AI code reviewer on this repo. Invoke it by commenting `/bonk` or `@ask-bonk` on a PR.