### PR TITLE
test: trigger Bonk review (avg empty-input guard)

### DIFF
--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,7 +1,8 @@
 export const sum = (vals: number[]): number =>
   vals.reduce((agg, val) => agg + val, 0);
 
-export const avg = (vals: number[]): number => sum(vals) / vals.length;
+export const avg = (vals: number[]): number =>
+  vals.length ? sum(vals) / vals.length : 0;
 
 /**
  * Returns the value at the given percentile using linear interpolation.


### PR DESCRIPTION
Test PR to verify the Bonk AI reviewer auto-runs on PR open.

Change: `avg()` now returns `0` for empty input instead of `NaN`, consistent with `percentile()`.

Will close after confirming Bonk posts a review.