### PR TITLE
fix: restore user-facing ConfigOptions and export phase types

### DIFF
--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -35,12 +35,13 @@ export type MeasurementConfig =
   | PacketLossMeasurementConfig;
 
 /**
- * User-facing configuration for the speed test engine.
+ * Fully-specified speed test configuration — every option present.
  *
- * All properties have sensible defaults defined in {@link defaultConfig}.
- * Pass a partial object to the engine constructor to override individual values.
+ * This is the shape of {@link defaultConfig}. Consumers don't construct this
+ * directly; they pass a {@link ConfigOptions} (a partial) to the engine, which
+ * merges it over the defaults.
  */
-export interface ConfigOptions {
+export interface Config {
   /** Whether to start the test immediately on construction. Default: `true`. */
   autoStart: boolean;
 
@@ -108,9 +109,18 @@ export interface ConfigOptions {
   loadedLatencyMaxPoints: number;
 }
 
+/**
+ * User-facing configuration for the speed test engine.
+ *
+ * A partial of {@link Config}: pass any subset to the engine constructor to
+ * override individual options; omitted properties fall back to their defaults
+ * in {@link defaultConfig}.
+ */
+export type ConfigOptions = Partial<Config>;
+
 const REL_API_URL = 'https://speed.cloudflare.com';
 
-const defaultConfig: ConfigOptions = {
+const defaultConfig: Config = {
   // Engine
   autoStart: true,
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,7 @@ export { default as defaultConfig } from './defaultConfig';
 export { default as internalConfig } from './internalConfig';
 
 export type {
+  Config,
   ConfigOptions,
   MeasurementConfig,
   LatencyMeasurementConfig,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,8 @@
 export { default as defaultConfig } from './defaultConfig';
 export { default as internalConfig } from './internalConfig';
 
+// NOTE: `Config` is internal-only — intentionally NOT re-exported from
+// src/index.ts. The public surface is `ConfigOptions = Partial<Config>`.
 export type {
   Config,
   ConfigOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
   defaultConfig,
   internalConfig,
+  type Config,
   type ConfigOptions,
   type InternalConfig
 } from './config';
@@ -65,18 +66,10 @@ interface MeasurementStep {
 }
 
 /** The merged config object (defaultConfig + userConfig + internalConfig). */
-type SpeedTestConfig = ConfigOptions &
+type SpeedTestConfig = Config &
   InternalConfig & { measurements: MeasurementStep[] } & {
     [key: string]: unknown;
   };
-
-/**
- * Partial user-supplied configuration.
- *
- * Pass to the engine constructor to override any property from
- * {@link ConfigOptions}. Omitted properties use their defaults.
- */
-type UserConfig = Partial<SpeedTestConfig>;
 
 /** Per-type measurement result bucket stored in Results.raw. */
 interface MeasurementResult {
@@ -125,7 +118,7 @@ const genMeasId = (): string => `${Math.round(Math.random() * 1e16)}`;
  * ```
  */
 class MeasurementEngine {
-  constructor(userConfig: UserConfig = {}) {
+  constructor(userConfig: ConfigOptions = {}) {
     this.#config = Object.assign(
       {},
       defaultConfig,
@@ -709,7 +702,7 @@ class MeasurementEngine {
  * ```
  */
 class SpeedTestEngine extends MeasurementEngine {
-  constructor(userConfig: UserConfig = {}) {
+  constructor(userConfig: ConfigOptions = {}) {
     super(userConfig);
     super.onFinish = this.#logFinalResults;
 
@@ -755,7 +748,7 @@ class SpeedTestEngine extends MeasurementEngine {
 
 export default SpeedTestEngine;
 
-export type { UserConfig };
+export type { MeasurementType, MeasurementStep, PhaseChangePayload };
 export { type default as Results } from './Results';
 export type {
   BandwidthPoint,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import {
   internalConfig,
   type Config,
   type ConfigOptions,
-  type InternalConfig
+  type InternalConfig,
+  type MeasurementConfig
 } from './config';
 import { type Engine } from './engines/Engine';
 import BandwidthEngine from './engines/BandwidthEngine/LoggingBandwidthEngine';
@@ -86,7 +87,7 @@ interface PhaseChangePayload {
   /** Index of the current measurement step within the configured measurements array. */
   measurementId: number;
   /** Configuration of the measurement phase that is starting. */
-  measurement: MeasurementStep;
+  measurement: MeasurementConfig;
 }
 
 /**
@@ -326,7 +327,7 @@ class MeasurementEngine {
 
     this.onPhaseChange({
       measurementId: this.#curMsmIdx,
-      measurement: { type, ...msmConfig }
+      measurement: { type, ...msmConfig } as MeasurementConfig
     });
 
     const { downloadApiUrl, uploadApiUrl, estimatedServerTime } = this.#config;
@@ -748,7 +749,7 @@ class SpeedTestEngine extends MeasurementEngine {
 
 export default SpeedTestEngine;
 
-export type { MeasurementType, MeasurementStep, PhaseChangePayload };
+export type { MeasurementType, PhaseChangePayload };
 export { type default as Results } from './Results';
 export type {
   BandwidthPoint,

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,10 @@ class MeasurementEngine {
 
     this.onPhaseChange({
       measurementId: this.#curMsmIdx,
+      // Only the user-configurable subset reaches here: `Config.measurements` is
+      // typed `MeasurementConfig[]`, so the extra runtime types in the switch
+      // below (latencyUnderLoad/packetLossUnderLoad/reachability/rpki/nxdomain)
+      // are never present in the public config and the cast is sound.
       measurement: { type, ...msmConfig } as MeasurementConfig
     });
 


### PR DESCRIPTION
## Summary

The TypeScript migration (`v1.10.0`) unintentionally changed several **public exported types**, breaking consumers that upgraded from `1.9.x`. This patch restores the prior public contract (types only — no runtime behavior change).

What `1.10.0` broke:

1. **`ConfigOptions` lost its optionality.** In `1.9.x` it was the *user-facing partial* config (every field optional) — the shape passed to the engine constructor. The migration repurposed `ConfigOptions` as the fully-resolved internal config (every field **required**) and renamed the partial to `UserConfig`. Any consumer annotating its config object as `ConfigOptions` now fails with "missing properties `turnServerUser`, `turnServerPass`, …".
2. **The phase-change `measurement` type changed** from the documented `MeasurementConfig` to an internal loose `MeasurementStep` (which wasn't exported), breaking consumers that type their `onPhaseChange` handlers.

## Changes

- Introduce an internal `interface Config` (all options present — the shape of `defaultConfig`) and export **`ConfigOptions = Partial<Config>`** again. This is the shape the engine constructor accepts, matching `1.9.x`. `Config` is intentionally **not** re-exported from the package root.
- Remove `UserConfig` (consumers use `ConfigOptions`).
- **Keep `MeasurementStep` internal** and type **`PhaseChangePayload.measurement` as `MeasurementConfig`** (cast the internal value at the single emit site). `onPhaseChange` only ever emits one of the user-configured measurements, so `MeasurementConfig` is both accurate and faithful to `1.9.x`. `MeasurementStep` is just the loose internal shape that lets the engine's `switch` handle every runtime type — not something consumers should depend on.
- Export **`MeasurementType`** (to type `onResultsChange` handlers) and **`PhaseChangePayload`**.

`Results.raw` keeps its honest `RawResults` type (consumers that need the concrete per-config shape cast on their side).

## Verification

- `pnpm build` → `dist/speedtest.d.ts`: `ConfigOptions = Partial<Config>`; `Config`/`UserConfig`/`MeasurementStep` absent from the public exports; `PhaseChangePayload.measurement: MeasurementConfig`; `MeasurementType`/`PhaseChangePayload` exported.
- `pnpm lint` clean.
- `pnpm test:unit` — 93/93 pass.

Intended to ship as a **patch** release (`1.10.1`).