### PR TITLE
ci: update create-pull-request to v8 and publish GitHub Releases

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -35,7 +35,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: bump version to ${{ steps.bump.outputs.version }}"
           branch: releases/v${{ steps.bump.outputs.version }}

--- a/.github/workflows/pr-npm-publish.yml
+++ b/.github/workflows/pr-npm-publish.yml
@@ -47,3 +47,11 @@ jobs:
 
       - name: Publish to npm
         run: npm publish
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --generate-notes --verify-tag


### PR DESCRIPTION
## Summary

Two CI/release improvements:

1. **Fix the Node 20 deprecation warning.** The `Create Release PR` workflow used `peter-evans/create-pull-request@v7`, which runs on the deprecated Node 20 runtime. Bumped to **`@v8`** (Node 24). `v8.0.0` is purely the runtime bump — no input/behavior changes — so it's a drop-in. ([v8 release notes](https://github.com/peter-evans/create-pull-request/releases/tag/v8.0.0))

2. **Publish GitHub Releases with notes.** The publish workflow previously only pushed a bare git tag — the repo has 39 tags but **zero GitHub Releases**, so there's no per-version changelog. Added a step that runs `gh release create … --generate-notes` after `npm publish`, so every release now gets a Release page with auto-generated notes (merged PRs since the previous tag + contributors + full-changelog link).

## Details

- The release step is placed **after** `npm publish` so a failed publish won't create a release.
- Uses the existing `contents: write` permission and the preinstalled `gh` CLI; `--verify-tag` ensures the tag (pushed in the prior step) exists.
- Notes are flat for now (no `.github/release.yml` categorization). Conventional-commit PR titles already read cleanly; categorization (Features/Bug Fixes) can be layered on later via `release.yml` + labels or release-please.
- Only affects future releases. Recent past tags can be backfilled separately with `gh release create <tag> --generate-notes --notes-start-tag <prev>`.

## Risk

CI/workflow-only; no library code or types changed. The publish workflow only triggers on merged `releases/*` PRs.