### PR TITLE
feat: report server-accepted upload bytes in results

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,5 +63,13 @@ export default [
         'URLSearchParams'
       ]
     }
+  },
+  {
+    // Tests run in Node and headless Chromium, not the browsers the library
+    // targets, so browser-compat checks don't apply to them.
+    files: ['tests/**/*.ts'],
+    rules: {
+      'compat/compat': 'off'
+    }
   }
 ];

--- a/src/Results/MeasurementCalculations.ts
+++ b/src/Results/MeasurementCalculations.ts
@@ -82,14 +82,23 @@ class MeasurementCalculations {
     Object.entries(bandwidthResults)
       .map(([bytes, { timings }]) =>
         timings.map(
-          ({ bps, duration, ping, measTime, serverTime, transferSize }) => ({
+          ({
+            bps,
+            duration,
+            ping,
+            measTime,
+            serverTime,
+            transferSize,
+            uploadBytes
+          }) => ({
             bytes: +bytes,
             bps,
             duration,
             ping,
             measTime,
             serverTime,
-            transferSize
+            transferSize,
+            uploadBytes
           })
         )
       )

--- a/src/engines/BandwidthEngine/BandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/BandwidthEngine.ts
@@ -84,6 +84,8 @@ export interface BandwidthMeasurementTiming {
   ping: number;
   duration: number;
   bps: number | undefined;
+  /** Server-accepted upload size (bytes) from `cf-meta-upload-bytes`, uploads only. */
+  uploadBytes?: number;
 }
 
 export interface BandwidthTimingResult extends BandwidthMeasurementTiming {

--- a/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
@@ -7,6 +7,25 @@ import type {
 } from './BandwidthEngine';
 import type { ParallelLatencyOptions } from './ParallelLatency';
 
+export const parseUploadBytesHeader = (
+  headers: Headers
+): number | undefined => {
+  const value = headers.get('cf-meta-upload-bytes');
+  if (!value || !/^\d+$/.test(value)) return undefined;
+
+  const bytes = Number(value);
+  return Number.isSafeInteger(bytes) ? bytes : undefined;
+};
+
+/** Upload logs use server-accepted bytes when the server reports a cap. */
+export const getLoggedBytes = (
+  measData: Pick<BandwidthTimingResult, 'type' | 'bytes'>,
+  uploadBytes: number | undefined
+): number =>
+  measData.type === 'up' && uploadBytes !== undefined
+    ? uploadBytes
+    : measData.bytes;
+
 export interface LoggingBandwidthEngineOptions extends ParallelLatencyOptions {
   measurementId?: string;
   logApiUrl?: string;
@@ -38,8 +57,10 @@ class LoggingBandwidthEngine extends BandwidthEngine {
     super.qsParams = logApiUrl ? { measId: this.#measurementId! } : {};
     super.responseHook = (r: ResponseHookPayload) =>
       this.#loggingResponseHook(r);
-    super.onMeasurementResult = (meas: BandwidthTimingResult) =>
+    super.onMeasurementResult = (meas: BandwidthTimingResult) => {
+      this.#applyUploadBytes(meas);
       this.#logMeasurement(meas);
+    };
   }
 
   // Overridden attributes
@@ -66,6 +87,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
       meas: BandwidthTimingResult,
       ...restArgs: [BandwidthEngineResults]
     ) => {
+      this.#applyUploadBytes(meas);
       onMeasurementResult(meas, ...restArgs);
       this.#logMeasurement(meas);
     };
@@ -75,11 +97,27 @@ class LoggingBandwidthEngine extends BandwidthEngine {
   #measurementId: string | undefined;
   #token: string | null | undefined;
   #requestTime: number | null | undefined;
+  #uploadBytes: number | undefined;
   #logApiUrl: string | undefined;
   #sessionId: string | undefined;
 
   // Internal methods
+
+  /**
+   * Records server-accepted upload bytes on the measurement result so the
+   * final results payload can report the actual uploaded size (uploads only).
+   */
+  #applyUploadBytes(measData: BandwidthTimingResult): void {
+    if (measData.type === 'up' && this.#uploadBytes !== undefined) {
+      measData.uploadBytes = this.#uploadBytes;
+    }
+  }
+
   #loggingResponseHook(r: ResponseHookPayload): void {
+    // Capture server-accepted upload bytes regardless of per-measurement
+    // logging, so the final results payload can report actual uploaded sizes.
+    this.#uploadBytes = parseUploadBytesHeader(r.headers);
+
     if (!this.#logApiUrl) return;
 
     // get request time
@@ -94,7 +132,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
 
     const logData = {
       type: measData.type,
-      bytes: measData.bytes,
+      bytes: getLoggedBytes(measData, this.#uploadBytes),
       ping: Math.round(measData.ping), // round to ms
       ttfb: Math.round(measData.ttfb), // round to ms
       payloadDownloadTime: Math.round(measData.payloadDownloadTime),
@@ -109,6 +147,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
 
     this.#token = null;
     this.#requestTime = null;
+    this.#uploadBytes = undefined;
 
     fetch(this.#logApiUrl, {
       method: 'POST',

--- a/src/logging/logFinalResults.ts
+++ b/src/logging/logFinalResults.ts
@@ -50,10 +50,14 @@ const round = (
 const latencyPointsParser: ParserFn = durations =>
   (durations as number[]).map(d => round(d, 2));
 
-/** Extracts bytes and rounded bps from each bandwidth data point. */
+/**
+ * Extracts bytes and rounded bps from each bandwidth data point. For uploads,
+ * `bytes` is the server-accepted size (`cf-meta-upload-bytes`) when reported,
+ * falling back to the requested size; downloads always use the requested size.
+ */
 const bpsPointsParser: ParserFn = pnts =>
   (pnts as BandwidthPoint[]).map(d => ({
-    bytes: +d.bytes,
+    bytes: d.uploadBytes ?? +d.bytes,
     bps: round(d.bps)
   }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,13 @@ export interface BandwidthTiming {
 
   /** Actual number of bytes transferred (from `PerformanceResourceTiming`). */
   transferSize: number;
+
+  /**
+   * Server-accepted upload size (bytes), from the `cf-meta-upload-bytes`
+   * response header. Present only for upload requests where the server
+   * reported how much of the body it accepted (e.g. when it caps the upload).
+   */
+  uploadBytes?: number;
 }
 
 /**
@@ -87,6 +94,13 @@ export interface BandwidthPoint {
 
   /** From `PerformanceResourceTiming`. */
   transferSize: number;
+
+  /**
+   * Server-accepted upload size (bytes), from the `cf-meta-upload-bytes`
+   * response header. Present only for upload points where the server reported
+   * how much of the body it accepted.
+   */
+  uploadBytes?: number;
 }
 
 /** Results from a packet-loss measurement via WebRTC TURN relay. */

--- a/tests/e2e/support/globalSetup.ts
+++ b/tests/e2e/support/globalSetup.ts
@@ -1,0 +1,19 @@
+import { startMockServer, type MockServer } from './mockServer';
+import type { GlobalSetupContext } from 'vitest/node';
+
+declare module 'vitest' {
+  interface ProvidedContext {
+    mockBaseUrl: string;
+  }
+}
+
+let mock: MockServer | undefined;
+
+export default async function setup({ provide }: GlobalSetupContext) {
+  mock = await startMockServer();
+  provide('mockBaseUrl', mock.url);
+
+  return async () => {
+    await mock?.close();
+  };
+}

--- a/tests/e2e/support/mockServer.ts
+++ b/tests/e2e/support/mockServer.ts
@@ -1,0 +1,136 @@
+import { createServer } from 'node:http';
+
+/**
+ * Minimal mock of the speed.cloudflare.com transfer endpoints, used by the
+ * upload-bytes e2e test. It lets the test force the server-accepted upload size
+ * to differ from the request Content-Length, so we can prove the client logs
+ * the `cf-meta-upload-bytes` header value rather than the body size.
+ *
+ * Upload behavior is selected via the `mode` query param on `/__up`:
+ *  - `half` -> returns `cf-meta-upload-bytes: floor(receivedBytes / 2)`
+ *             (server "accepts" fewer bytes than were sent)
+ *  - `none` -> omits the header entirely (exercises the client fallback)
+ *  - otherwise -> returns `cf-meta-upload-bytes: receivedBytes`
+ *
+ * POST bodies sent to `/__log` and `/__results` are captured and exposed via
+ * `GET /__captured` so the browser test can read them back.
+ */
+
+interface LogEntry {
+  sessionId?: string;
+  type?: string;
+  bytes?: number;
+}
+
+interface ResultsPayload {
+  sessionId?: string;
+  upload?: Array<{ bytes: number }>;
+}
+
+interface Captured {
+  log: LogEntry[];
+  results: ResultsPayload[];
+}
+
+export interface MockServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+const CORS: Record<string, string> = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET,POST,OPTIONS',
+  'access-control-allow-headers': '*',
+  'access-control-expose-headers': 'cf-meta-upload-bytes, server-timing',
+  'timing-allow-origin': '*'
+};
+
+const MAX_DOWNLOAD_BYTES = 5_000_000;
+
+export async function startMockServer(): Promise<MockServer> {
+  const captured: Captured = { log: [], results: [] };
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const path = url.pathname;
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, CORS);
+      res.end();
+      return;
+    }
+
+    if (req.method === 'GET' && path === '/__down') {
+      const requested = Number(url.searchParams.get('bytes') ?? '0');
+      const size = Number.isFinite(requested)
+        ? Math.max(0, Math.min(requested, MAX_DOWNLOAD_BYTES))
+        : 0;
+      res.writeHead(200, {
+        ...CORS,
+        'content-type': 'application/octet-stream'
+      });
+      res.end(Buffer.alloc(size, 0x30));
+      return;
+    }
+
+    if (req.method === 'POST' && path === '/__up') {
+      let received = 0;
+      req.on('data', chunk => {
+        received += chunk.length;
+      });
+      req.on('end', () => {
+        const mode = url.searchParams.get('mode');
+        const headers: Record<string, string> = { ...CORS };
+        if (mode === 'half') {
+          headers['cf-meta-upload-bytes'] = String(Math.floor(received / 2));
+        } else if (mode !== 'none') {
+          headers['cf-meta-upload-bytes'] = String(received);
+        }
+        res.writeHead(200, headers);
+        res.end('___mock-token');
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && (path === '/__log' || path === '/__results')) {
+      let body = '';
+      req.on('data', chunk => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        try {
+          const parsed = JSON.parse(body);
+          if (path === '/__log') {
+            captured.log.push(parsed as LogEntry);
+          } else {
+            captured.results.push(parsed as ResultsPayload);
+          }
+        } catch {
+          // ignore malformed bodies
+        }
+        res.writeHead(200, CORS);
+        res.end('ok');
+      });
+      return;
+    }
+
+    if (req.method === 'GET' && path === '/__captured') {
+      res.writeHead(200, { ...CORS, 'content-type': 'application/json' });
+      res.end(JSON.stringify(captured));
+      return;
+    }
+
+    res.writeHead(404, CORS);
+    res.end('not found');
+  });
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>(resolve => server.close(() => resolve()))
+  };
+}

--- a/tests/e2e/uploadBytes.test.ts
+++ b/tests/e2e/uploadBytes.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, inject } from 'vitest';
+import SpeedTest from '../../src/index.ts';
+
+interface LogEntry {
+  sessionId?: string;
+  type?: string;
+  bytes?: number;
+}
+
+interface ResultsPayload {
+  sessionId?: string;
+  upload?: Array<{ bytes: number }>;
+}
+
+interface Captured {
+  log: LogEntry[];
+  results: ResultsPayload[];
+}
+
+const REQUESTED = 1e5;
+const UPLOAD_COUNT = 2;
+
+function runUpload(
+  base: string,
+  mode: 'half' | 'none',
+  sessionId: string
+): Promise<void> {
+  const engine = new SpeedTest({
+    autoStart: false,
+    sessionId,
+    downloadApiUrl: `${base}/__down`,
+    uploadApiUrl: `${base}/__up?mode=${mode}`,
+    logMeasurementApiUrl: `${base}/__log`,
+    logAimApiUrl: `${base}/__results`,
+    measureDownloadLoadedLatency: false,
+    measureUploadLoadedLatency: false,
+    measurements: [
+      { type: 'latency', numPackets: 1 },
+      { type: 'upload', bytes: REQUESTED, count: UPLOAD_COUNT }
+    ]
+  });
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error('speed test timed out')),
+      60_000
+    );
+    engine.onError = error => {
+      clearTimeout(timeout);
+      reject(new Error(`speed test error: ${error}`));
+    };
+    engine.onFinish = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    engine.play();
+  });
+}
+
+// The /__log and /__results POSTs are fire-and-forget, so poll until the
+// entries for this run's sessionId have arrived.
+async function waitForCaptured(
+  base: string,
+  sessionId: string
+): Promise<{ log: LogEntry[]; results: ResultsPayload[] }> {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const res = await fetch(`${base}/__captured`);
+    const data = (await res.json()) as Captured;
+    const log = data.log.filter(
+      l => l.sessionId === sessionId && l.type === 'up'
+    );
+    const results = data.results.filter(r => r.sessionId === sessionId);
+    if (log.length >= UPLOAD_COUNT && results.length >= 1) {
+      return { log, results };
+    }
+    await new Promise(resolve => setTimeout(resolve, 250));
+  }
+  throw new Error('captured __log/__results payloads did not arrive');
+}
+
+describe('upload bytes reporting (e2e)', () => {
+  it('logs the server cf-meta-upload-bytes value, not the Content-Length', async () => {
+    const base = inject('mockBaseUrl');
+    const sessionId = `cap-${Date.now()}`;
+    // Mock returns cf-meta-upload-bytes = floor(body / 2), i.e. fewer bytes
+    // than were actually uploaded (Content-Length === REQUESTED).
+    const accepted = Math.floor(REQUESTED / 2);
+
+    await runUpload(base, 'half', sessionId);
+    const { log, results } = await waitForCaptured(base, sessionId);
+
+    // /__log per-measurement upload entries
+    expect(log.length).toBe(UPLOAD_COUNT);
+    for (const entry of log) {
+      expect(entry.bytes).toBe(accepted);
+      expect(entry.bytes).not.toBe(REQUESTED);
+    }
+
+    // /__results final payload upload points
+    const uploadPoints = results[0].upload ?? [];
+    expect(uploadPoints.length).toBeGreaterThan(0);
+    for (const point of uploadPoints) {
+      expect(point.bytes).toBe(accepted);
+      expect(point.bytes).not.toBe(REQUESTED);
+    }
+  }, 90_000);
+
+  it('falls back to the requested bytes when cf-meta-upload-bytes is absent', async () => {
+    const base = inject('mockBaseUrl');
+    const sessionId = `none-${Date.now()}`;
+
+    await runUpload(base, 'none', sessionId);
+    const { log, results } = await waitForCaptured(base, sessionId);
+
+    expect(log.length).toBe(UPLOAD_COUNT);
+    for (const entry of log) {
+      expect(entry.bytes).toBe(REQUESTED);
+    }
+
+    const uploadPoints = results[0].upload ?? [];
+    expect(uploadPoints.length).toBeGreaterThan(0);
+    for (const point of uploadPoints) {
+      expect(point.bytes).toBe(REQUESTED);
+    }
+  }, 90_000);
+});

--- a/tests/unit/Results/MeasurementCalculations.test.ts
+++ b/tests/unit/Results/MeasurementCalculations.test.ts
@@ -119,6 +119,27 @@ describe('MeasurementCalculations', () => {
       expect(result[0].bytes).toBe(100000);
       expect(result[1].bytes).toBe(1000000);
     });
+
+    it('surfaces server-accepted upload bytes when present', () => {
+      const calc = createCalc();
+      const result = calc.getBandwidthPoints({
+        5000000000: {
+          timings: [
+            {
+              bps: 10e6,
+              duration: 100,
+              ping: 12,
+              measTime: new Date(200),
+              serverTime: 8,
+              transferSize: 4000000000,
+              uploadBytes: 4000000000
+            }
+          ]
+        }
+      });
+      expect(result[0].bytes).toBe(5000000000);
+      expect(result[0].uploadBytes).toBe(4000000000);
+    });
   });
 
   describe('getBandwidth', () => {

--- a/tests/unit/engines/loggingBandwidthEngine.test.ts
+++ b/tests/unit/engines/loggingBandwidthEngine.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getLoggedBytes,
+  parseUploadBytesHeader
+} from '../../../src/engines/BandwidthEngine/LoggingBandwidthEngine.ts';
+
+describe('LoggingBandwidthEngine', () => {
+  describe('parseUploadBytesHeader', () => {
+    it('reads a valid cf-meta-upload-bytes header', () => {
+      const headers = new Headers({ 'cf-meta-upload-bytes': '4000000000' });
+
+      expect(parseUploadBytesHeader(headers)).toBe(4000000000);
+    });
+
+    it('ignores missing or invalid cf-meta-upload-bytes headers', () => {
+      expect(parseUploadBytesHeader(new Headers())).toBeUndefined();
+      expect(
+        parseUploadBytesHeader(new Headers({ 'cf-meta-upload-bytes': '1e3' }))
+      ).toBeUndefined();
+      expect(
+        parseUploadBytesHeader(new Headers({ 'cf-meta-upload-bytes': '-1' }))
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getLoggedBytes', () => {
+    it('uses server-reported upload bytes for upload measurements', () => {
+      expect(
+        getLoggedBytes({ type: 'up', bytes: 5000000000 }, 4000000000)
+      ).toBe(4000000000);
+    });
+
+    it('falls back to measured bytes when the header is absent', () => {
+      expect(getLoggedBytes({ type: 'up', bytes: 5000000000 }, undefined)).toBe(
+        5000000000
+      );
+    });
+
+    it('does not override download measurements', () => {
+      expect(
+        getLoggedBytes({ type: 'down', bytes: 5000000000 }, 4000000000)
+      ).toBe(5000000000);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         test: {
           name: 'e2e',
           include: ['tests/e2e/**/*.test.ts'],
+          globalSetup: ['./tests/e2e/support/globalSetup.ts'],
           browser: {
             enabled: true,
             provider: playwright(),


### PR DESCRIPTION
Captures the `cf-meta-upload-bytes` response header on upload requests and surfaces the server-accepted upload size through the measurement results.

- `LoggingBandwidthEngine` reads `cf-meta-upload-bytes` on every response (independent of per-measurement logging) and attaches it to the upload measurement result.
- The accepted size is threaded through `Results` / `getBandwidthPoints`.
- The final results payload now reports the server-accepted upload size per point, falling back to the client-requested size when the header is absent. Downloads are unaffected.

Depends conceptually on the server returning `cf-meta-upload-bytes`; works regardless of whether the client sends `bytes=` on uploads (see #120).