### PR TITLE
feat: send bytes= query param on upload measurements

### DIFF
--- a/src/engines/BandwidthEngine/BandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/BandwidthEngine.ts
@@ -345,7 +345,7 @@ class BandwidthMeasurementEngine implements Engine {
 
     const apiUrl = isDown ? this.#downloadApi : this.#uploadApi;
     const qsParams: Record<string, string> = Object.assign({}, this.#qsParams);
-    isDown && (qsParams.bytes = `${numBytes}`);
+    qsParams.bytes = `${numBytes}`;
 
     const urlObj = new URL(apiUrl, window.location.origin);
     Object.entries(qsParams).forEach(([k, v]) => urlObj.searchParams.set(k, v));


### PR DESCRIPTION
Send the `bytes=<size>` query parameter on upload (POST /__up) requests, matching the existing behavior for download requests.

No user-visible behavior change for normal clients: `bytes=` matches the upload body size.