### PR TITLE
feat: surface AIM log response via onResultsLogged callback

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,18 +65,9 @@ export default [
     }
   },
   {
-    // Tests run in modern environments (Node + Vitest browser mode/Chromium),
-    // so the same web APIs are available as the polyfilled set used in src.
+    // Browser-compat checks apply to shipped library code (src), not tests,
+    // which run in Node + Vitest's Chromium.
     files: ['tests/**/*.ts'],
-    settings: {
-      polyfills: [
-        'Array.prototype.includes',
-        'Promise',
-        'fetch',
-        'Response',
-        'URL',
-        'URLSearchParams'
-      ]
-    }
+    rules: { 'compat/compat': 'off' }
   }
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,5 +63,20 @@ export default [
         'URLSearchParams'
       ]
     }
+  },
+  {
+    // Tests run in modern environments (Node + Vitest browser mode/Chromium),
+    // so the same web APIs are available as the polyfilled set used in src.
+    files: ['tests/**/*.ts'],
+    settings: {
+      polyfills: [
+        'Array.prototype.includes',
+        'Promise',
+        'fetch',
+        'Response',
+        'URL',
+        'URLSearchParams'
+      ]
+    }
   }
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,9 @@ import PacketLossEngine from './engines/PacketLossEngine';
 import ReachabilityEngine from './engines/ReachabilityEngine';
 
 import Results from './Results';
-import logFinalResults from './logging/logFinalResults';
+import logFinalResults, {
+  type AimLogResponse
+} from './logging/logFinalResults';
 
 const DEFAULT_OPTIMAL_DOWNLOAD_SIZE = 1e6;
 const DEFAULT_OPTIMAL_UPLOAD_SIZE = 1e6;
@@ -704,6 +706,7 @@ class MeasurementEngine {
  *
  * const engine = new SpeedTest();
  * engine.onFinish = results => console.log(results.getScores());
+ * engine.onResultsLogged = ({ requestId }) => console.log('Logged as', requestId);
  * ```
  */
 class SpeedTestEngine extends MeasurementEngine {
@@ -737,23 +740,40 @@ class SpeedTestEngine extends MeasurementEngine {
     };
   }
 
+  /**
+   * Called after the final results have been logged to the AIM API, with the
+   * endpoint's parsed response (e.g. the assigned `requestId`).
+   *
+   * Fires only when logging is enabled (`logAimApiUrl` is set) and the request
+   * succeeds. Because the log request completes after {@link onFinish}, this
+   * callback runs slightly later.
+   */
+  onResultsLogged: (response: AimLogResponse) => void = () => {};
+
   // Internal state
   readonly #logAimApiUrl: string | null;
   readonly #sessionId: string | undefined;
 
   // Internal methods
   #logFinalResults = (results: Results): void => {
-    this.#logAimApiUrl &&
-      logFinalResults(results, {
-        apiUrl: this.#logAimApiUrl,
-        sessionId: this.#sessionId
-      });
+    if (!this.#logAimApiUrl) {
+      return;
+    }
+    logFinalResults(results, {
+      apiUrl: this.#logAimApiUrl,
+      sessionId: this.#sessionId
+    }).then(response => {
+      if (response) {
+        this.onResultsLogged(response);
+      }
+    });
   };
 }
 
 export default SpeedTestEngine;
 
 export type { MeasurementType, PhaseChangePayload };
+export type { AimLogResponse } from './logging/logFinalResults';
 export { type default as Results } from './Results';
 export type {
   BandwidthPoint,

--- a/src/index.ts
+++ b/src/index.ts
@@ -744,8 +744,9 @@ class SpeedTestEngine extends MeasurementEngine {
    * Called after the final results have been logged to the AIM API, with the
    * endpoint's parsed response (e.g. the assigned `requestId`).
    *
-   * Fires only when logging is enabled (`logAimApiUrl` is set) and the request
-   * succeeds. Because the log request completes after {@link onFinish}, this
+   * Fires whenever logging is attempted (`logAimApiUrl` is set), after the log
+   * request completes — on success or failure. On failure, `requestId` is
+   * `undefined`. Because the log request completes after {@link onFinish}, this
    * callback runs slightly later.
    */
   onResultsLogged: (response: AimLogResponse) => void = () => {};
@@ -763,9 +764,7 @@ class SpeedTestEngine extends MeasurementEngine {
       apiUrl: this.#logAimApiUrl,
       sessionId: this.#sessionId
     }).then(response => {
-      if (response) {
-        this.onResultsLogged(response);
-      }
+      this.onResultsLogged(response);
     });
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -772,7 +772,7 @@ class SpeedTestEngine extends MeasurementEngine {
 export default SpeedTestEngine;
 
 export type { MeasurementType, PhaseChangePayload };
-export type { AimLogResponse } from './logging/logFinalResults';
+export type { AimLogResponse };
 export { type default as Results } from './Results';
 export type {
   BandwidthPoint,

--- a/src/logging/logFinalResults.ts
+++ b/src/logging/logFinalResults.ts
@@ -37,6 +37,13 @@ interface LogData {
   [key: string]: unknown;
 }
 
+/** Response returned by the AIM logging endpoint. */
+export interface AimLogResponse {
+  /** Unique identifier assigned to this measurement, used to look it up later. */
+  requestId?: string;
+  [key: string]: unknown;
+}
+
 type ParserFn = (val: unknown) => unknown;
 
 /** Rounds a number to a given number of decimal places. */
@@ -91,12 +98,15 @@ const scoreParser = (
 
 /**
  * Formats measurement results and AIM scores, then POSTs them to the
- * AIM logging endpoint. Fire-and-forget — errors are silently ignored.
+ * AIM logging endpoint. Best-effort — never throws.
+ *
+ * Resolves with the parsed JSON response from the endpoint (e.g. the assigned
+ * `requestId`), or `undefined` if the request failed or returned no usable body.
  */
-const logAimResults = (
+const logAimResults = async (
   results: Results,
   { apiUrl, sessionId }: LogConfig
-): void => {
+): Promise<AimLogResponse | undefined> => {
   const logData: LogData = {
     sessionId
   };
@@ -118,10 +128,18 @@ const logAimResults = (
     );
   }
 
-  fetch(apiUrl, {
-    method: 'POST',
-    body: JSON.stringify(logData)
-  });
+  try {
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      body: JSON.stringify(logData)
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+    return (await response.json()) as AimLogResponse;
+  } catch {
+    return undefined;
+  }
 };
 
 export default logAimResults;

--- a/src/logging/logFinalResults.ts
+++ b/src/logging/logFinalResults.ts
@@ -100,13 +100,14 @@ const scoreParser = (
  * Formats measurement results and AIM scores, then POSTs them to the
  * AIM logging endpoint. Best-effort — never throws.
  *
- * Resolves with the parsed JSON response from the endpoint (e.g. the assigned
- * `requestId`), or `undefined` if the request failed or returned no usable body.
+ * Always resolves with an {@link AimLogResponse}: the parsed response body on
+ * success (e.g. the assigned `requestId`), or `{ requestId: undefined }` if the
+ * request failed or returned no usable body.
  */
 const logAimResults = async (
   results: Results,
   { apiUrl, sessionId }: LogConfig
-): Promise<AimLogResponse | undefined> => {
+): Promise<AimLogResponse> => {
   const logData: LogData = {
     sessionId
   };
@@ -134,11 +135,11 @@ const logAimResults = async (
       body: JSON.stringify(logData)
     });
     if (!response.ok) {
-      return undefined;
+      return { requestId: undefined };
     }
     return (await response.json()) as AimLogResponse;
   } catch {
-    return undefined;
+    return { requestId: undefined };
   }
 };
 

--- a/src/logging/logFinalResults.ts
+++ b/src/logging/logFinalResults.ts
@@ -41,7 +41,6 @@ interface LogData {
 export interface AimLogResponse {
   /** Unique identifier assigned to this measurement, used to look it up later. */
   requestId?: string;
-  [key: string]: unknown;
 }
 
 type ParserFn = (val: unknown) => unknown;

--- a/tests/e2e/speedtest.test.ts
+++ b/tests/e2e/speedtest.test.ts
@@ -1,152 +1,203 @@
 import { describe, it, expect } from 'vitest';
-import SpeedTest from '../../src/index.ts';
+import SpeedTest, { type AimLogResponse } from '../../src/index.ts';
 
 const VALID_CLASSIFICATIONS = ['bad', 'poor', 'average', 'good', 'great'];
 
+// AIM logging endpoint used by this test. The request is intercepted (see the
+// fetch stub below) so the assertion does not depend on a live endpoint.
+const AIM_LOG_URL = 'https://speed.cloudflare.com/__results';
+const STUB_REQUEST_ID = '11111111-2222-3333-4444-555555555555';
+
 describe('SpeedTest E2E', () => {
-  it('runs a realistic speed test and produces valid results', {
-    timeout: 120_000,
-    retry: 2
-  }, async () => {
-    const engine = new SpeedTest({
-      autoStart: false,
-      logAimApiUrl: null,
-      logMeasurementApiUrl: null,
-      measurements: [
-        // Phase 1: Initial estimation
-        { type: 'latency', numPackets: 1 },
-        { type: 'download', bytes: 1e5, count: 1, bypassMinDuration: true },
-        // Phase 2: Latency measurement
-        { type: 'latency', numPackets: 10 },
-        // Phase 3: Progressive downloads
-        { type: 'download', bytes: 1e5, count: 4 },
-        { type: 'download', bytes: 1e6, count: 3 },
-        { type: 'download', bytes: 1e7, count: 2 },
-        // Phase 4: Progressive uploads
-        { type: 'upload', bytes: 1e5, count: 4 },
-        { type: 'upload', bytes: 1e6, count: 3 },
-        { type: 'upload', bytes: 1e7, count: 2 }
-      ],
-      measureDownloadLoadedLatency: true,
-      measureUploadLoadedLatency: true,
-      // Lower the min duration threshold so fast CI connections still
-      // produce loaded latency data (default 250ms filters out fast downloads)
-      loadedRequestMinDuration: 10
-    });
+  it(
+    'runs a realistic speed test and produces valid results',
+    {
+      timeout: 120_000,
+      retry: 2
+    },
+    async () => {
+      const engine = new SpeedTest({
+        autoStart: false,
+        logAimApiUrl: AIM_LOG_URL,
+        logMeasurementApiUrl: null,
+        measurements: [
+          // Phase 1: Initial estimation
+          { type: 'latency', numPackets: 1 },
+          { type: 'download', bytes: 1e5, count: 1, bypassMinDuration: true },
+          // Phase 2: Latency measurement
+          { type: 'latency', numPackets: 10 },
+          // Phase 3: Progressive downloads
+          { type: 'download', bytes: 1e5, count: 4 },
+          { type: 'download', bytes: 1e6, count: 3 },
+          { type: 'download', bytes: 1e7, count: 2 },
+          // Phase 4: Progressive uploads
+          { type: 'upload', bytes: 1e5, count: 4 },
+          { type: 'upload', bytes: 1e6, count: 3 },
+          { type: 'upload', bytes: 1e7, count: 2 }
+        ],
+        measureDownloadLoadedLatency: true,
+        measureUploadLoadedLatency: true,
+        // Lower the min duration threshold so fast CI connections still
+        // produce loaded latency data (default 250ms filters out fast downloads)
+        loadedRequestMinDuration: 10
+      });
 
-    // Run the speed test and wait for completion
-    const resultsObj = await new Promise<typeof engine.results>(
-      (resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error('Speed test timed out after 90 seconds'));
-        }, 90_000);
+      // Intercept only the AIM log POST so we can deterministically assert that
+      // onResultsLogged fires with the endpoint's parsed response. All other
+      // requests (download/upload/latency) hit the real network as usual.
+      const originalFetch = window.fetch;
+      const restoreFetch = () => {
+        window.fetch = originalFetch;
+      };
+      window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof Request
+              ? input.url
+              : input.toString();
+        if (url === AIM_LOG_URL) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ requestId: STUB_REQUEST_ID }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' }
+            })
+          );
+        }
+        return originalFetch(input, init);
+      };
 
-        engine.onFinish = results => {
-          clearTimeout(timeout);
-          resolve(results);
-        };
+      // onResultsLogged fires after onFinish (once the log request resolves).
+      const aimResponsePromise = new Promise<AimLogResponse>(resolve => {
+        engine.onResultsLogged = resolve;
+      });
 
-        engine.onError = error => {
-          clearTimeout(timeout);
-          reject(new Error(`Speed test error: ${error}`));
-        };
+      // Run the speed test and wait for completion
+      const resultsObj = await new Promise<typeof engine.results>(
+        (resolve, reject) => {
+          const timeout = setTimeout(() => {
+            restoreFetch();
+            reject(new Error('Speed test timed out after 90 seconds'));
+          }, 90_000);
 
-        engine.play();
-      }
-    );
+          engine.onFinish = results => {
+            clearTimeout(timeout);
+            resolve(results);
+          };
 
-    // ── Engine state ──────────────────────────────────────────────
-    expect(resultsObj.isFinished).toBe(true);
+          engine.onError = error => {
+            clearTimeout(timeout);
+            restoreFetch();
+            reject(new Error(`Speed test error: ${error}`));
+          };
 
-    // ── Summary values with reasonable ranges ─────────────────────
-    const summary = resultsObj.getSummary();
-
-    // Latency: should be between 0 and 1000ms from any CI runner
-    expect(summary.latency).toBeGreaterThan(0);
-    expect(summary.latency).toBeLessThan(1000);
-
-    // Jitter: should be between 0 and 500ms
-    expect(summary.jitter).toBeGreaterThanOrEqual(0);
-    expect(summary.jitter).toBeLessThan(500);
-
-    // Download bandwidth: at least 1 Kbps (any CI runner can do this)
-    expect(summary.download).toBeGreaterThan(1000);
-
-    // Upload bandwidth: at least 1 Kbps
-    expect(summary.upload).toBeGreaterThan(1000);
-
-    // Loaded latency (download): may be absent on very fast connections
-    // where the parallel latency engine doesn't collect data before
-    // downloads finish. When present, should be reasonable.
-    if (summary.downLoadedLatency !== undefined) {
-      expect(summary.downLoadedLatency).toBeGreaterThanOrEqual(0);
-      expect(summary.downLoadedLatency).toBeLessThan(5000);
-    }
-    if (summary.downLoadedJitter !== undefined) {
-      expect(summary.downLoadedJitter).toBeGreaterThanOrEqual(0);
-      expect(summary.downLoadedJitter).toBeLessThan(2000);
-    }
-
-    // Loaded latency (upload): same caveat as download
-    if (summary.upLoadedLatency !== undefined) {
-      expect(summary.upLoadedLatency).toBeGreaterThanOrEqual(0);
-      expect(summary.upLoadedLatency).toBeLessThan(5000);
-    }
-    if (summary.upLoadedJitter !== undefined) {
-      expect(summary.upLoadedJitter).toBeGreaterThanOrEqual(0);
-      expect(summary.upLoadedJitter).toBeLessThan(2000);
-    }
-
-    // Total duration: between 1 second and 2 minutes
-    expect(summary.totalDurationMs).toBeGreaterThan(1000);
-    expect(summary.totalDurationMs).toBeLessThan(120_000);
-
-    // ── Raw data points ───────────────────────────────────────────
-
-    // Download bandwidth points
-    const dlPoints = resultsObj.getDownloadBandwidthPoints();
-    expect(dlPoints.length).toBeGreaterThan(0);
-    for (const p of dlPoints) {
-      expect(p.bytes).toBeGreaterThan(0);
-      expect(p.bps).toBeGreaterThan(0);
-      expect(p.duration).toBeGreaterThan(0);
-    }
-
-    // Upload bandwidth points
-    const ulPoints = resultsObj.getUploadBandwidthPoints();
-    expect(ulPoints.length).toBeGreaterThan(0);
-    for (const p of ulPoints) {
-      expect(p.bytes).toBeGreaterThan(0);
-      expect(p.bps).toBeGreaterThan(0);
-      expect(p.duration).toBeGreaterThan(0);
-    }
-
-    // Unloaded latency points
-    const latencyPoints = resultsObj.getUnloadedLatencyPoints();
-    expect(latencyPoints.length).toBeGreaterThan(0);
-    for (const p of latencyPoints) {
-      expect(p).toBeGreaterThan(0);
-      expect(p).toBeLessThan(1000);
-    }
-
-    // Loaded latency points (download) — may be empty on fast connections
-    const dlLoadedPoints = resultsObj.getDownLoadedLatencyPoints();
-    for (const p of dlLoadedPoints) {
-      expect(p).toBeGreaterThan(0);
-      expect(p).toBeLessThan(5000);
-    }
-
-    // ── AIM Scores ────────────────────────────────────────────────
-    const scores = resultsObj.getScores();
-
-    for (const experience of ['streaming', 'gaming', 'rtc']) {
-      expect(scores[experience]).toBeDefined();
-      expect(scores[experience].points).toBeGreaterThanOrEqual(0);
-      expect(scores[experience].classificationIdx).toBeGreaterThanOrEqual(0);
-      expect(scores[experience].classificationIdx).toBeLessThanOrEqual(4);
-      expect(VALID_CLASSIFICATIONS).toContain(
-        scores[experience].classificationName
+          engine.play();
+        }
       );
+
+      // Wait for the AIM log request to resolve, then restore fetch before
+      // running assertions so a failure never leaves the global patched.
+      const aimResponse = await aimResponsePromise;
+      restoreFetch();
+
+      // ── Engine state ──────────────────────────────────────────────
+      expect(resultsObj.isFinished).toBe(true);
+
+      // ── Summary values with reasonable ranges ─────────────────────
+      const summary = resultsObj.getSummary();
+
+      // Latency: should be between 0 and 1000ms from any CI runner
+      expect(summary.latency).toBeGreaterThan(0);
+      expect(summary.latency).toBeLessThan(1000);
+
+      // Jitter: should be between 0 and 500ms
+      expect(summary.jitter).toBeGreaterThanOrEqual(0);
+      expect(summary.jitter).toBeLessThan(500);
+
+      // Download bandwidth: at least 1 Kbps (any CI runner can do this)
+      expect(summary.download).toBeGreaterThan(1000);
+
+      // Upload bandwidth: at least 1 Kbps
+      expect(summary.upload).toBeGreaterThan(1000);
+
+      // Loaded latency (download): may be absent on very fast connections
+      // where the parallel latency engine doesn't collect data before
+      // downloads finish. When present, should be reasonable.
+      if (summary.downLoadedLatency !== undefined) {
+        expect(summary.downLoadedLatency).toBeGreaterThanOrEqual(0);
+        expect(summary.downLoadedLatency).toBeLessThan(5000);
+      }
+      if (summary.downLoadedJitter !== undefined) {
+        expect(summary.downLoadedJitter).toBeGreaterThanOrEqual(0);
+        expect(summary.downLoadedJitter).toBeLessThan(2000);
+      }
+
+      // Loaded latency (upload): same caveat as download
+      if (summary.upLoadedLatency !== undefined) {
+        expect(summary.upLoadedLatency).toBeGreaterThanOrEqual(0);
+        expect(summary.upLoadedLatency).toBeLessThan(5000);
+      }
+      if (summary.upLoadedJitter !== undefined) {
+        expect(summary.upLoadedJitter).toBeGreaterThanOrEqual(0);
+        expect(summary.upLoadedJitter).toBeLessThan(2000);
+      }
+
+      // Total duration: between 1 second and 2 minutes
+      expect(summary.totalDurationMs).toBeGreaterThan(1000);
+      expect(summary.totalDurationMs).toBeLessThan(120_000);
+
+      // ── Raw data points ───────────────────────────────────────────
+
+      // Download bandwidth points
+      const dlPoints = resultsObj.getDownloadBandwidthPoints();
+      expect(dlPoints.length).toBeGreaterThan(0);
+      for (const p of dlPoints) {
+        expect(p.bytes).toBeGreaterThan(0);
+        expect(p.bps).toBeGreaterThan(0);
+        expect(p.duration).toBeGreaterThan(0);
+      }
+
+      // Upload bandwidth points
+      const ulPoints = resultsObj.getUploadBandwidthPoints();
+      expect(ulPoints.length).toBeGreaterThan(0);
+      for (const p of ulPoints) {
+        expect(p.bytes).toBeGreaterThan(0);
+        expect(p.bps).toBeGreaterThan(0);
+        expect(p.duration).toBeGreaterThan(0);
+      }
+
+      // Unloaded latency points
+      const latencyPoints = resultsObj.getUnloadedLatencyPoints();
+      expect(latencyPoints.length).toBeGreaterThan(0);
+      for (const p of latencyPoints) {
+        expect(p).toBeGreaterThan(0);
+        expect(p).toBeLessThan(1000);
+      }
+
+      // Loaded latency points (download) — may be empty on fast connections
+      const dlLoadedPoints = resultsObj.getDownLoadedLatencyPoints();
+      for (const p of dlLoadedPoints) {
+        expect(p).toBeGreaterThan(0);
+        expect(p).toBeLessThan(5000);
+      }
+
+      // ── AIM Scores ────────────────────────────────────────────────
+      const scores = resultsObj.getScores();
+
+      for (const experience of ['streaming', 'gaming', 'rtc']) {
+        expect(scores[experience]).toBeDefined();
+        expect(scores[experience].points).toBeGreaterThanOrEqual(0);
+        expect(scores[experience].classificationIdx).toBeGreaterThanOrEqual(0);
+        expect(scores[experience].classificationIdx).toBeLessThanOrEqual(4);
+        expect(VALID_CLASSIFICATIONS).toContain(
+          scores[experience].classificationName
+        );
+      }
+
+      // ── onResultsLogged ───────────────────────────────────────────
+      // The engine logged the results to the AIM endpoint and surfaced the
+      // parsed response (the assigned requestId) via onResultsLogged.
+      expect(aimResponse).toEqual({ requestId: STUB_REQUEST_ID });
     }
-  });
+  );
 });

--- a/tests/e2e/speedtest.test.ts
+++ b/tests/e2e/speedtest.test.ts
@@ -67,7 +67,8 @@ describe('SpeedTest E2E', () => {
         return originalFetch(input, init);
       };
 
-      // onResultsLogged fires after onFinish (once the log request resolves).
+      // onResultsLogged fires shortly after onFinish (once the log request
+      // resolves).
       const aimResponsePromise = new Promise<AimLogResponse>(resolve => {
         engine.onResultsLogged = resolve;
       });
@@ -95,10 +96,25 @@ describe('SpeedTest E2E', () => {
         }
       );
 
-      // Wait for the AIM log request to resolve, then restore fetch before
-      // running assertions so a failure never leaves the global patched.
-      const aimResponse = await aimResponsePromise;
-      restoreFetch();
+      // The log request resolves shortly after onFinish; bound the wait so a
+      // regression that stops onResultsLogged firing fails fast with a clear
+      // message instead of hanging until the test timeout. Restore fetch before
+      // assertions so a failure never leaves the global patched.
+      let aimLogTimer: ReturnType<typeof setTimeout> | undefined;
+      const aimLogTimeout = new Promise<never>((_, reject) => {
+        aimLogTimer = setTimeout(
+          () =>
+            reject(new Error('onResultsLogged did not fire within 15s of finish')),
+          15_000
+        );
+      });
+      let aimResponse: AimLogResponse;
+      try {
+        aimResponse = await Promise.race([aimResponsePromise, aimLogTimeout]);
+      } finally {
+        clearTimeout(aimLogTimer);
+        restoreFetch();
+      }
 
       // ── Engine state ──────────────────────────────────────────────
       expect(resultsObj.isFinished).toBe(true);

--- a/tests/unit/logging/logFinalResults.test.ts
+++ b/tests/unit/logging/logFinalResults.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import logAimResults from '../../../src/logging/logFinalResults.ts';
+import type Results from '../../../src/Results';
+
+/** Minimal Results stub — logAimResults only calls these getters. */
+const makeResults = (): Results =>
+  ({
+    getUnloadedLatencyPoints: () => [],
+    getDownloadBandwidthPoints: () => [],
+    getUploadBandwidthPoints: () => [],
+    getDownLoadedLatencyPoints: () => [],
+    getUpLoadedLatencyPoints: () => [],
+    getPacketLossDetails: () => undefined,
+    getTotalDurationMs: () => 1234,
+    getScores: () => undefined
+  }) as unknown as Results;
+
+const config = {
+  apiUrl: 'https://aim.example.com/__results',
+  sessionId: undefined
+};
+
+describe('logAimResults', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs the results to the configured apiUrl', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await logAimResults(makeResults(), config);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(config.apiUrl);
+    expect(init.method).toBe('POST');
+  });
+
+  it('resolves with the parsed response body (e.g. requestId)', async () => {
+    const requestId = '11111111-2222-3333-4444-555555555555';
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ requestId }), { status: 200 })
+        )
+    );
+
+    const result = await logAimResults(makeResults(), config);
+
+    expect(result).toEqual({ requestId });
+  });
+
+  it('resolves with undefined on a non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('nope', { status: 500 }))
+    );
+
+    expect(await logAimResults(makeResults(), config)).toBeUndefined();
+  });
+
+  it('resolves with undefined when the request rejects', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('network down'))
+    );
+
+    expect(await logAimResults(makeResults(), config)).toBeUndefined();
+  });
+
+  it('resolves with undefined when the response body is not JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('not json', { status: 200 }))
+    );
+
+    expect(await logAimResults(makeResults(), config)).toBeUndefined();
+  });
+});

--- a/tests/unit/logging/logFinalResults.test.ts
+++ b/tests/unit/logging/logFinalResults.test.ts
@@ -41,6 +41,9 @@ describe('logAimResults', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(config.apiUrl);
     expect(init.method).toBe('POST');
+    // The module's main job is formatting logData — assert it lands in the body.
+    const body = JSON.parse(init.body);
+    expect(body.totalDurationMs).toBe(1234);
   });
 
   it('resolves with the parsed response body (e.g. requestId)', async () => {

--- a/tests/unit/logging/logFinalResults.test.ts
+++ b/tests/unit/logging/logFinalResults.test.ts
@@ -59,30 +59,36 @@ describe('logAimResults', () => {
     expect(result).toEqual({ requestId });
   });
 
-  it('resolves with undefined on a non-ok response', async () => {
+  it('resolves with { requestId: undefined } on a non-ok response', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(new Response('nope', { status: 500 }))
     );
 
-    expect(await logAimResults(makeResults(), config)).toBeUndefined();
+    expect(await logAimResults(makeResults(), config)).toEqual({
+      requestId: undefined
+    });
   });
 
-  it('resolves with undefined when the request rejects', async () => {
+  it('resolves with { requestId: undefined } when the request rejects', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockRejectedValue(new Error('network down'))
     );
 
-    expect(await logAimResults(makeResults(), config)).toBeUndefined();
+    expect(await logAimResults(makeResults(), config)).toEqual({
+      requestId: undefined
+    });
   });
 
-  it('resolves with undefined when the response body is not JSON', async () => {
+  it('resolves with { requestId: undefined } when the response body is not JSON', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(new Response('not json', { status: 200 }))
     );
 
-    expect(await logAimResults(makeResults(), config)).toBeUndefined();
+    expect(await logAimResults(makeResults(), config)).toEqual({
+      requestId: undefined
+    });
   });
 });


### PR DESCRIPTION
The engine already POSTs final results to the AIM endpoint but discarded the response, so consumers had no way to read the `requestId` it assigns. This adds an `onResultsLogged(response)` callback that fires with that response (`{ requestId }`) once logging completes — letting speed.cloudflare.com and Radar show/look up a test by its id instead of monkey-patching `window.fetch`. Kept separate from `onFinish` (logging happens after, and is optional/can fail). Additive, backwards-compatible.
