### PR TITLE
Improve latency calculation based on server timings and connect times

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Prettier + ESLint run on commit via `lint-staged` (Husky pre-commit hook).
 ## Architecture
 
 - `src/index.ts` — entrypoint. Exports `LoggingMeasurementEngine` (default),
-  which wraps `MeasurementEngine` and logs results to `aim.cloudflare.com`.
+  which wraps `MeasurementEngine` and logs results to `speed.cloudflare.com/__results`.
 - `src/config/` — default config and AIM scoring thresholds.
 - `src/engines/` — sub-engines for each measurement type:
   - `BandwidthEngine/` — HTTP fetch-based download/upload via `PerformanceResourceTiming`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ new SpeedTest({ configOptions })
 | **loadedLatencyThrottle**: *number* | Time interval to wait in between loaded latency requests (in milliseconds). | 400 |
 | **bandwidthFinishRequestDuration**: *number* | The minimum duration (in milliseconds) to reach in download/upload measurement sets for halting further measurements with larger file sizes in the same direction. | 1000 |
 | **bandwidthAbortRequestDuration**: *number* | The minimum duration (in milliseconds) to reach in download/upload measurement sets for aborting the test early | 0 (disabled) |
-| **estimatedServerTime**: *number* | If the download/upload APIs do not return a server-timing response header containing the time spent in the server, this fixed value (in milliseconds) will be subtracted from all time-to-first-byte calculations. | 10 |
+| **estimatedServerTime**: *number* | If the download/upload APIs do not return a `server-timing` response header containing the time spent in the server, this fixed value (in milliseconds) will be subtracted from all time-to-first-byte calculations. | 0 |
 | **latencyPercentile**: *number* | The percentile (between 0 and 1) used to calculate latency from a set of measurements. | 0.5 |
 | **bandwidthPercentile**: *number* | The percentile (between 0 and 1) used to calculate bandwidth from a set of measurements. | 0.9 |
 | **bandwidthMinRequestDuration**: *number* | The minimum duration (in milliseconds) of a request to consider a measurement good enough to use in the bandwidth calculation. | 10 |

--- a/example/basic-page/local.html
+++ b/example/basic-page/local.html
@@ -1,0 +1,46 @@
+<body>
+  <div id="controls"></div>
+  <div id="result"></div>
+
+  <script type="module">
+    import SpeedTest from '../../dist/speedtest.js';
+
+    const controlEl = document.getElementById('controls');
+    const resEl = document.getElementById('result');
+
+    const engine = new SpeedTest({
+      autoStart: false
+    });
+    engine.onRunningChange = running => controlEl.textContent = running ? 'Running...' : 'Finished!';
+    engine.onResultsChange = ({ type }) => {
+      const raw = engine.results.raw;
+      !engine.isFinished && setResult(raw);
+      const summary = engine.results.getSummary();
+      console.log(type, {
+        latency: summary.latency,
+        download: summary.download,
+        upload: summary.upload,
+        loadedLatency: summary.downLoadedLatency || summary.upLoadedLatency
+      });
+    };
+    engine.onFinish = results => {
+      setResult(results.getSummary());
+      console.log(results.getSummary());
+      console.log(results.getScores());
+    };
+
+    engine.onError = (e) => console.log(e);
+
+    const playButton = document.createElement('button');
+    playButton.textContent = "Start Speed Measurement";
+    playButton.onclick = () => engine.play();
+    controlEl.appendChild(playButton);
+
+    function setResult(obj) {
+      const resTxt = document.createElement('pre');
+      resTxt.textContent = JSON.stringify(obj, null, 2);
+      resEl.textContent = '';
+      resEl.appendChild(resTxt);
+    }
+  </script>
+</body>

--- a/example/basic-page/local2.html
+++ b/example/basic-page/local2.html
@@ -1,0 +1,56 @@
+<body>
+  <div id="controls"></div>
+  <div id="result"></div>
+
+  <script type="module">
+    import SpeedTest from '../../dist/speedtest.js';
+
+    const controlEl = document.getElementById('controls');
+    const resEl = document.getElementById('result');
+
+    const engine = new SpeedTest({
+      autoStart: false,
+      downloadApiUrl: 'http://localhost:8787/__down',
+      uploadApiUrl: 'http://localhost:8787/__up'
+    });
+    engine.onRunningChange = running => controlEl.textContent = running ? 'Running...' : 'Finished!';
+    engine.onResultsChange = ({ type }) => {
+      !engine.isFinished && setResult(engine.results.raw);
+      console.log(type);
+
+      // Log connection timing for the latest request
+      const entries = performance.getEntries().filter(e => e.name.includes('__down') || e.name.includes('__up'));
+      const e = entries[entries.length - 1];
+      if (e) {
+        console.log({
+          url: e.name.split('?')[0],
+          protocol: e.nextHopProtocol,
+          connectStart: e.connectStart,
+          connectEnd: e.connectEnd,
+          secureConnectionStart: e.secureConnectionStart,
+          connectTime: e.connectEnd - e.connectStart,
+          ttfb: e.responseStart - e.requestStart
+        });
+      }
+    };
+    engine.onFinish = results => {
+      setResult(results.getSummary());
+      console.log(results.getSummary());
+      console.log(results.getScores());
+    };
+
+    engine.onError = (e) => console.log(e);
+
+    const playButton = document.createElement('button');
+    playButton.textContent = "Start Speed Measurement";
+    playButton.onclick = () => engine.play();
+    controlEl.appendChild(playButton);
+
+    function setResult(obj) {
+      const resTxt = document.createElement('pre');
+      resTxt.textContent = JSON.stringify(obj, null, 2);
+      resEl.textContent = '';
+      resEl.appendChild(resTxt);
+    }
+  </script>
+</body>

--- a/example/basic-page/production.html
+++ b/example/basic-page/production.html
@@ -1,0 +1,42 @@
+<body>
+  <div id="controls"></div>
+  <div id="result"></div>
+
+  <script type="module">
+    import SpeedTest from '../../dist/speedtest.js';
+
+    const PRODUCTION = 'https://production.speed.cloudflare.com';
+
+    const controlEl = document.getElementById('controls');
+    const resEl = document.getElementById('result');
+
+    const engine = new SpeedTest({
+      autoStart: false,
+      downloadApiUrl: `${PRODUCTION}/__down`,
+      uploadApiUrl: `${PRODUCTION}/__up`
+    });
+    engine.onRunningChange = running => controlEl.textContent = running ? 'Running...' : 'Finished!';
+    engine.onResultsChange = ({ type }) => {
+      !engine.isFinished && setResult(engine.results.raw);
+    };
+    engine.onFinish = results => {
+      setResult(results.getSummary());
+      console.log(results.getSummary());
+      console.log(results.getScores());
+    };
+
+    engine.onError = (e) => console.log(e);
+
+    const playButton = document.createElement('button');
+    playButton.textContent = "Start Speed Measurement";
+    playButton.onclick = () => engine.play();
+    controlEl.appendChild(playButton);
+
+    function setResult(obj) {
+      const resTxt = document.createElement('pre');
+      resTxt.textContent = JSON.stringify(obj, null, 2);
+      resEl.textContent = '';
+      resEl.appendChild(resTxt);
+    }
+  </script>
+</body>

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -51,7 +51,7 @@ export interface Config {
   uploadApiUrl: string;
   /** URL for per-measurement logging. Set to `null` to disable. Default: `null`. */
   logMeasurementApiUrl: string | null;
-  /** URL for AIM score logging. Set to `null` to disable. Default: `https://aim.cloudflare.com/__log`. */
+  /** URL for logging test results. Set to `null` to disable. Default: `https://speed.cloudflare.com/__results`. */
   logAimApiUrl: string | null;
   /** TURN server URI for packet loss measurement. Default: `turn.speed.cloudflare.com:50000`. */
   turnServerUri: string;
@@ -128,7 +128,7 @@ const defaultConfig: Config = {
   downloadApiUrl: `${REL_API_URL}/__down`,
   uploadApiUrl: `${REL_API_URL}/__up`,
   logMeasurementApiUrl: null,
-  logAimApiUrl: 'https://aim.cloudflare.com/__log',
+  logAimApiUrl: `${REL_API_URL}/__results`,
   turnServerUri: 'turn.speed.cloudflare.com:50000',
   turnServerCredsApiUrl: `${REL_API_URL}/turn-creds`,
   turnServerUser: null,

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -139,12 +139,15 @@ const defaultConfig: Config = {
 
   // Measurements
   measurements: [
-    { type: 'latency', numPackets: 1 }, // initial ttfb estimation
+    { type: 'latency', numPackets: 2 }, // initial ttfb estimation
     { type: 'download', bytes: 1e5, count: 1, bypassMinDuration: true }, // initial download estimation
     { type: 'latency', numPackets: 20 },
     { type: 'download', bytes: 1e5, count: 9 },
+    { type: 'latency', numPackets: 2 },
     { type: 'download', bytes: 1e6, count: 8 },
+    { type: 'latency', numPackets: 2 },
     { type: 'upload', bytes: 1e5, count: 8 },
+    { type: 'latency', numPackets: 2 },
     {
       type: 'packetLoss',
       numPackets: 1e3,
@@ -153,12 +156,19 @@ const defaultConfig: Config = {
       responsesWaitTime: 3000 // ms (silent time after last sent msg)
     },
     { type: 'upload', bytes: 1e6, count: 6 },
+    { type: 'latency', numPackets: 2 },
     { type: 'download', bytes: 1e7, count: 6 },
+    { type: 'latency', numPackets: 2 },
     { type: 'upload', bytes: 1e7, count: 4 },
+    { type: 'latency', numPackets: 2 },
     { type: 'download', bytes: 2.5e7, count: 4 },
+    { type: 'latency', numPackets: 2 },
     { type: 'upload', bytes: 2.5e7, count: 4 },
+    { type: 'latency', numPackets: 2 },
     { type: 'download', bytes: 1e8, count: 3 },
+    { type: 'latency', numPackets: 2 },
     { type: 'upload', bytes: 5e7, count: 3 },
+    { type: 'latency', numPackets: 2 },
     { type: 'download', bytes: 2.5e8, count: 2 }
   ],
   measureDownloadLoadedLatency: true,

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -87,7 +87,7 @@ export interface Config {
   bandwidthFinishRequestDuration: number;
   /**
    * Estimated server processing time (ms) subtracted from raw latency when
-   * the server doesn't report its own processing time in headers. Default: `10`.
+   * the server doesn't report its own processing time in headers. Default: `0`.
    */
   estimatedServerTime: number;
 
@@ -165,7 +165,7 @@ const defaultConfig: Config = {
   measureUploadLoadedLatency: true,
   loadedLatencyThrottle: 400, // ms in between loaded latency requests
   bandwidthFinishRequestDuration: 1000, // download/upload duration (ms) to reach for stopping further measurements of that type
-  estimatedServerTime: 10, // ms to discount from latency calculation (if not present in response headers)
+  estimatedServerTime: 0, // ms to discount from latency calculation (if not present in response headers)
 
   // Test abort
   bandwidthAbortRequestDuration: 0, // download/upload duration (ms) to abort measurement early and stop further measurements of that type

--- a/src/engines/BandwidthEngine/BandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/BandwidthEngine.ts
@@ -4,14 +4,29 @@ const MAX_RETRIES = 20;
 
 const ESTIMATED_HEADER_FRACTION = 0.005; // ~.5% of packet header / payload size. used when transferSize is not available.
 
-/** Extract server processing time from the `Server-Timing` response header. */
+const SERVER_TIME_MIN_DURATION = 0.01; // minimum server-provided duration value to consider valid (ms)
+const SERVER_TIME_DELTA_MAX = 15; // max server time delta to accept (ms)
+const SERVER_TIME_CALIBRATION_MAX = 150; // max server time for delta calibration (ms)
+const SERVER_TIME_DELTA_WEIGHT = 0.75; // weight of new delta observations (0-1), blended with previous value
+
+// extract the server time from server-timing header(s)
 const cfGetServerTime = (r: Response): number | undefined => {
-  // extract server-timing from headers: server-timing: cfRequestDuration;dur=15.999794
   const serverTiming = r.headers.get(`server-timing`);
-  if (serverTiming) {
-    const re = serverTiming.match(/(?:^|;)\s*dur=([0-9.]+)/);
-    if (re) return +re[1];
+  if (!serverTiming) return;
+
+  const re = serverTiming.match(
+    /(?:^|,\s*)cfReq(?:uest)?Dur(?:ation)?;\s*dur=([0-9.]+)/i
+  );
+  if (re && +re[1] > SERVER_TIME_MIN_DURATION) return +re[1];
+
+  let sum = 0;
+  for (const m of serverTiming.matchAll(
+    /(?:^|,\s*)cfSpeed[a-zA-Z]*;\s*dur=([0-9.]+)/gi
+  )) {
+    sum += +m[1];
   }
+  if (sum > SERVER_TIME_MIN_DURATION) return sum;
+  return undefined;
 };
 
 /** Time to first byte: time from request start to first response byte (ms). */
@@ -112,6 +127,7 @@ export interface BandwidthEngineOptions {
   uploadApiUrl?: string;
   throttleMs?: number;
   estimatedServerTime?: number;
+  serverTimeDelta?: number;
 }
 
 /**
@@ -127,7 +143,8 @@ class BandwidthMeasurementEngine implements Engine {
       downloadApiUrl,
       uploadApiUrl,
       throttleMs = 0,
-      estimatedServerTime = 0
+      estimatedServerTime = 0,
+      serverTimeDelta = 0
     }: BandwidthEngineOptions = {}
   ) {
     if (!measurements) throw new Error('Missing measurements argument');
@@ -139,12 +156,17 @@ class BandwidthMeasurementEngine implements Engine {
     this.#uploadApi = uploadApiUrl;
     this.#throttleMs = throttleMs;
     this.#estimatedServerTime = Math.max(0, estimatedServerTime);
+    this.#serverTimeDelta = Math.max(0, serverTimeDelta);
   }
 
   // Public attributes
   get results(): BandwidthEngineResults {
     // read access to results
     return this.#results;
+  }
+
+  get serverTimeDelta(): number {
+    return this.#serverTimeDelta;
   }
 
   #qsParams: Record<string, string> = {}; // additional query string params to include in the requests
@@ -233,6 +255,7 @@ class BandwidthMeasurementEngine implements Engine {
   #minDuration: number = -Infinity; // of current measurement
   #throttleMs: number = 0;
   #estimatedServerTime: number = 0;
+  #serverTimeDelta: number = 0;
 
   /**
    * Aborts the current measurement.
@@ -420,11 +443,45 @@ class BandwidthMeasurementEngine implements Engine {
           duration: 0,
           bps: undefined
         };
-        timing.ping = Math.max(
-          1e-2,
-          timing.ttfb - (serverTime || this.#estimatedServerTime)
-        ); // ttfb = network latency + server time
+        // Detect new TCP connection from handshake timings.
+        let connectTime = 0;
+        if (perf.secureConnectionStart > perf.connectStart) {
+          connectTime = perf.secureConnectionStart - perf.connectStart;
+        } else {
+          connectTime = perf.connectEnd - perf.connectStart;
+        }
 
+        const protoMatch = perf.nextHopProtocol.match(/([0-9.]+)/);
+        const httpVersion = protoMatch ? +protoMatch[1] : 0;
+
+        // Calibrate serverTimeDelta from new TCP connections (HTTP/1.1)
+        if (serverTime && connectTime && httpVersion > 0 && httpVersion < 2) {
+          const derivedTotalServerTime = Math.max(0, timing.ttfb - connectTime);
+          const delta = derivedTotalServerTime - serverTime;
+          if (
+            delta > 0 &&
+            delta <= SERVER_TIME_DELTA_MAX &&
+            delta <= serverTime &&
+            serverTime <= SERVER_TIME_CALIBRATION_MAX
+          ) {
+            this.#serverTimeDelta =
+              this.#serverTimeDelta * (1 - SERVER_TIME_DELTA_WEIGHT) +
+              delta * SERVER_TIME_DELTA_WEIGHT;
+            console.log(
+              `serverTimeDelta (estimated): ${this.#serverTimeDelta.toFixed(2)}ms`
+            );
+          } else if (delta > 0) {
+            console.log(`serverTimeDelta (skipped): ${delta.toFixed(2)}ms`);
+          }
+        }
+
+        const baseServerTime = serverTime || this.#estimatedServerTime;
+        timing.ping = timing.ttfb - baseServerTime - this.#serverTimeDelta;
+
+        // Discard the delta adjustment if it would collapse the ping
+        if (timing.ping <= 1) {
+          timing.ping = Math.max(0, timing.ttfb - baseServerTime);
+        }
         timing.duration = (isDown ? calcDownloadDuration : calcUploadDuration)(
           timing
         );
@@ -432,6 +489,27 @@ class BandwidthMeasurementEngine implements Engine {
           timing,
           numBytes
         );
+
+        // Log measurement details
+        const delta = this.#serverTimeDelta;
+        if (+numBytes === 0) {
+          console.log('latency', {
+            phase: `during ${qsParams.during || 'idle'}`,
+            ttfb: timing.ttfb,
+            serverTime: baseServerTime,
+            ...(delta && { serverTimeDelta: delta }),
+            ping: timing.ping
+          });
+        } else {
+          console.log(isDown ? 'download' : 'upload', {
+            bytes: +numBytes,
+            bps: timing.bps,
+            ttfb: timing.ttfb,
+            serverTime: baseServerTime,
+            ...(delta && { serverTimeDelta: delta }),
+            ping: timing.ping
+          });
+        }
 
         if (isDown && numBytes) {
           const reqSize = +numBytes;
@@ -496,4 +574,5 @@ class BandwidthMeasurementEngine implements Engine {
   }
 }
 
+export { cfGetServerTime };
 export default BandwidthMeasurementEngine;

--- a/src/engines/BandwidthEngine/ParallelLatency.ts
+++ b/src/engines/BandwidthEngine/ParallelLatency.ts
@@ -25,6 +25,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
       downloadApiUrl,
       uploadApiUrl,
       estimatedServerTime = 0,
+      serverTimeDelta = 0,
       ...ptProps
     }: ParallelLatencyOptions = {}
   ) {
@@ -32,6 +33,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
       downloadApiUrl,
       uploadApiUrl,
       estimatedServerTime,
+      serverTimeDelta,
       ...ptProps
     });
 
@@ -49,6 +51,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
           downloadApiUrl,
           uploadApiUrl,
           estimatedServerTime,
+          serverTimeDelta,
           throttleMs: parallelLatencyThrottleMs
         }
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -695,7 +695,7 @@ class MeasurementEngine {
 
 /**
  * Extended {@link MeasurementEngine} that automatically logs final AIM scores
- * to `aim.cloudflare.com` when the test completes.
+ * to the configured `logAimApiUrl` when the test completes.
  *
  * This is the default export of the library and the recommended entry point
  * for most consumers.

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,6 +205,7 @@ class MeasurementEngine {
   readonly #results: Results;
 
   #measurementId: string = genMeasId();
+  #serverTimeDelta: number = 0;
   #curMsmIdx: number = -1;
   #curEngine: Engine | undefined;
   #optimalDownloadChunkSize: number = DEFAULT_OPTIMAL_DOWNLOAD_SIZE;
@@ -486,6 +487,7 @@ class MeasurementEngine {
             downloadApiUrl,
             uploadApiUrl,
             estimatedServerTime,
+            serverTimeDelta: this.#serverTimeDelta,
             logApiUrl: this.#config.logMeasurementApiUrl ?? undefined,
             measurementId: this.#measurementId,
             sessionId: this.#config.sessionId,
@@ -508,6 +510,11 @@ class MeasurementEngine {
           engine as Engine & { abortRequestDuration: number }
         ).abortRequestDuration = this.#config.bandwidthAbortRequestDuration;
 
+        if (!msmConfig.loadDown && !msmConfig.loadUp) {
+          const eng = engine as Engine & { qsParams: Record<string, string> };
+          eng.qsParams = { ...eng.qsParams, during: 'idle' };
+        }
+
         engine.onMeasurementResult = engine.onNewMeasurementStarted = (
           _meas: unknown,
           results: unknown
@@ -518,12 +525,14 @@ class MeasurementEngine {
         };
 
         engine.onFinished = () => {
+          this.#serverTimeDelta = (engine as BandwidthEngine).serverTimeDelta;
           msmResults.finished = true;
           this.onResultsChange({ type });
           this.#running && this.#next();
         };
 
         engine.onConnectionError = (e: unknown) => {
+          this.#serverTimeDelta = (engine as BandwidthEngine).serverTimeDelta;
           msmResults.error = e;
           this.onResultsChange({ type });
           this.#onError(`Connection error while measuring latency: ${e}`);
@@ -554,6 +563,7 @@ class MeasurementEngine {
               downloadApiUrl,
               uploadApiUrl,
               estimatedServerTime,
+              serverTimeDelta: this.#serverTimeDelta,
               logApiUrl: this.#config.logMeasurementApiUrl ?? undefined,
               measurementId: this.#measurementId,
               measureParallelLatency,
@@ -626,6 +636,7 @@ class MeasurementEngine {
           };
 
           engine.onFinished = (results: unknown) => {
+            this.#serverTimeDelta = (engine as BandwidthEngine).serverTimeDelta;
             const bwResults = results as Record<
               string,
               Record<
@@ -674,6 +685,7 @@ class MeasurementEngine {
           };
 
           engine.onConnectionError = (e: unknown) => {
+            this.#serverTimeDelta = (engine as BandwidthEngine).serverTimeDelta;
             msmResults.error = e;
             this.onResultsChange({ type });
             this.#onError(`Connection error while measuring ${type}: ${e}`);

--- a/tests/unit/engines/serverTiming.test.ts
+++ b/tests/unit/engines/serverTiming.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { cfGetServerTime } from '../../../src/engines/BandwidthEngine/BandwidthEngine';
+
+const mockResponse = (serverTiming: string) =>
+  new Response('', { headers: { 'server-timing': serverTiming } });
+
+describe('cfGetServerTime', () => {
+  it('prefers cfReqDur over cfSpeed*', () => {
+    const r = mockResponse(
+      'cfSpeedEdge;dur=10, cfSpeedWorker;dur=20, cfReqDur;dur=45.5'
+    );
+    expect(cfGetServerTime(r)).toBe(45.5);
+  });
+
+  it('sums cfSpeed* entries when cfReqDur is absent', () => {
+    const r = mockResponse('cfSpeedEdge;dur=10, cfSpeedWorker;dur=20');
+    expect(cfGetServerTime(r)).toBe(30);
+  });
+
+  it('returns undefined when no relevant metrics', () => {
+    const r = mockResponse('cfL4;desc="?proto=TCP&rtt=0"');
+    expect(cfGetServerTime(r)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Improve accuracy of latency calculations by making use of additional "thinking time" sent by the server, and by using the observed TCP RTT as fine tuning.