### PR TITLE
Fix multiple idle latency steps overriding previous measurements

### DIFF
--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -74,6 +74,10 @@ export interface Config {
    * Each entry describes a latency, bandwidth, or packet loss step.
    * The engine executes them sequentially, skipping further rounds of a
    * bandwidth type once its finish threshold is reached.
+   *
+   * Multiple `latency`, `download`, and `upload` steps accumulate their
+   * results. Other measurement types (e.g. `packetLoss`) replace prior
+   * results if multiple steps of the same type are configured.
    */
   measurements: MeasurementConfig[];
   measureDownloadLoadedLatency: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -471,7 +471,7 @@ class MeasurementEngine {
 
         break;
       case 'latency':
-      case 'latencyUnderLoad':
+      case 'latencyUnderLoad': {
         msmResults.finished = false;
 
         engine = new BandwidthEngine(
@@ -515,12 +515,21 @@ class MeasurementEngine {
           eng.qsParams = { ...eng.qsParams, during: 'idle' };
         }
 
+        // Accumulate timings across latency phases
+        const priorTimings = (
+          (msmResults.results as { timings?: unknown[] })?.timings || []
+        ).slice();
+
         engine.onMeasurementResult = engine.onNewMeasurementStarted = (
           _meas: unknown,
           results: unknown
         ) => {
           const res = results as Record<string, Record<number, unknown>>;
           msmResults.results = Object.assign({}, res.down[0]);
+          (msmResults.results as { timings: unknown[] }).timings =
+            priorTimings.concat(
+              (msmResults.results as { timings: unknown[] }).timings
+            );
           this.onResultsChange({ type });
         };
 
@@ -541,6 +550,7 @@ class MeasurementEngine {
 
         (engine as Engine & { play: () => void }).play!();
         break;
+      }
       case 'download':
       case 'upload':
         if (msmResults.finished || msmResults.error) {

--- a/src/logging/logFinalResults.ts
+++ b/src/logging/logFinalResults.ts
@@ -128,6 +128,8 @@ const logAimResults = async (
     );
   }
 
+  console.log('results', logData);
+
   try {
     const response = await fetch(apiUrl, {
       method: 'POST',


### PR DESCRIPTION
When multiple `{ type: 'latency' }` steps exist in the measurements config (e.g. the interleaved 2-ping idle probes added between bandwidth phases), each step was overwriting the previous step's timings in `raw.latency.results`. Only the last latency phase's data survived.

This fix snapshots the existing timings before each latency phase starts and prepends them on each measurement callback, so all phases accumulate into a single timings array.

Also logs the results payload to the console before submission to `__results`.