### PR TITLE
fix: send the authorization token in a header, not the URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ Prettier + ESLint run on commit via `lint-staged` (Husky pre-commit hook).
   - `ReachabilityEngine/` — simple fetch with timeout
 - `src/Results/` — aggregation, stats (percentile, jitter), and AIM scoring.
 - `src/utils/` — small helpers: math (`sum`, `avg`, `percentile`, `scaleThreshold`)
-  and `authorization` (attaches the `authorizationToken` to the API URLs).
+  and `authorization` (attaches the `authorizationToken` as an `Authorization`
+  header to the requests that carry it).
 - `example/turn-worker/` — separate Cloudflare Worker sub-project with its own
   `package.json` and Prettier config; not part of the library build.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ Prettier + ESLint run on commit via `lint-staged` (Husky pre-commit hook).
 - `src/Results/` — aggregation, stats (percentile, jitter), and AIM scoring.
 - `src/utils/` — small helpers: math (`sum`, `avg`, `percentile`, `scaleThreshold`)
   and `authorization` (attaches the `authorizationToken` as an `Authorization`
-  header to the requests that carry it).
+  header to the requests that carry it, withholding it from non-HTTPS endpoints
+  unless `allowInsecureAuthorizationToken` is set).
 - `example/turn-worker/` — separate Cloudflare Worker sub-project with its own
   `package.json` and Prettier config; not part of the library build.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,10 @@ Prettier + ESLint run on commit via `lint-staged` (Husky pre-commit hook).
 - `src/Results/` — aggregation, stats (percentile, jitter), and AIM scoring.
 - `src/utils/` — small helpers: math (`sum`, `avg`, `percentile`, `scaleThreshold`)
   and `authorization` (attaches the `authorizationToken` as an `Authorization`
-  header to the requests that carry it, withholding it from non-HTTPS endpoints
-  unless `allowInsecureAuthorizationToken` is set).
+  header to the requests that carry it, gated on `authorizationEnabled` and
+  withheld from non-HTTPS endpoints unless `allowInsecureAuthorizationToken`
+  is set). The whole authorization feature is **experimental/unstable** —
+  options are marked 🧪 in the README and `@experimental` in their JSDoc.
 - `example/turn-worker/` — separate Cloudflare Worker sub-project with its own
   `package.json` and Prettier config; not part of the library build.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ new SpeedTest({ configOptions })
 | **turnServerCredsApiUrl**: *string* | A URI that returns TURN server credentials. Expects a JSON response with `username` and `credential` keys. | - | 
 | **turnServerUser**: *string* | The username for the TURN server credentials. | - |
 | **turnServerPass**: *string* | The password for the TURN server credentials. | - |
-| **authorizationToken**: *string* | An opaque token attributing the test to a registered customer, sent as an `Authorization: Bearer` header on the measurement, TURN credential and results-logging requests. Obtain it from your own backend — the engine never requests one itself. Never sent over plain HTTP. | `null` |
+| **authorizationToken**: *string* | An opaque token attributing the test to a registered customer, sent as an `Authorization: Bearer` header on the measurement, TURN credential and results-logging requests. Obtain it from your own backend — the engine never requests one itself. Not sent over plain HTTP unless `allowInsecureAuthorizationToken` is set. | `null` |
+| **allowInsecureAuthorizationToken**: *boolean* | Sends `authorizationToken` even when the endpoint is not HTTPS, for local development against an `http://` server. Never enable this in production: the server treats a token seen over plaintext as compromised and revokes it. | `false` |
 | **measurements**: *array* | The sequence of measurements to perform by the speedtest engine. See [below](#measurement-config) for the specific syntax of this option. ||
 | **measureDownloadLoadedLatency**: *boolean* | Whether to perform additional latency measurements simultaneously with download requests, to measure loaded latency (during download). | `true` |
 | **measureUploadLoadedLatency**: *boolean* | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload). | `true` |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ new SpeedTest({ configOptions })
 | **turnServerCredsApiUrl**: *string* | A URI that returns TURN server credentials. Expects a JSON response with `username` and `credential` keys. | - | 
 | **turnServerUser**: *string* | The username for the TURN server credentials. | - |
 | **turnServerPass**: *string* | The password for the TURN server credentials. | - |
-| **authorizationToken**: *string* | An opaque token attributing the test to a registered customer, sent as a `jwt` query-string parameter on the measurement, TURN credential and results-logging requests. Obtain it from your own backend — the engine never requests one itself. Never sent over plain HTTP. | `null` |
+| **authorizationToken**: *string* | An opaque token attributing the test to a registered customer, sent as an `Authorization: Bearer` header on the measurement, TURN credential and results-logging requests. Obtain it from your own backend — the engine never requests one itself. Never sent over plain HTTP. | `null` |
 | **measurements**: *array* | The sequence of measurements to perform by the speedtest engine. See [below](#measurement-config) for the specific syntax of this option. ||
 | **measureDownloadLoadedLatency**: *boolean* | Whether to perform additional latency measurements simultaneously with download requests, to measure loaded latency (during download). | `true` |
 | **measureUploadLoadedLatency**: *boolean* | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload). | `true` |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ new SpeedTest().onFinish = results => console.log(results.getSummary());
 new SpeedTest({ configOptions })
 ```
 
+Options marked 🧪 are **experimental and unstable**: they may change behaviour,
+be renamed, or be removed in any release, including a patch. Do not depend on
+them.
+
 | Config option | Description | Default |
 | --- | --- | :--: |
 | **autoStart**: *boolean* | Whether to automatically start the measurements on instantiation. | `true` |
@@ -48,8 +52,9 @@ new SpeedTest({ configOptions })
 | **turnServerCredsApiUrl**: *string* | A URI that returns TURN server credentials. Expects a JSON response with `username` and `credential` keys. | - | 
 | **turnServerUser**: *string* | The username for the TURN server credentials. | - |
 | **turnServerPass**: *string* | The password for the TURN server credentials. | - |
-| **authorizationToken**: *string* | An opaque token attributing the test to a registered customer, sent as an `Authorization: Bearer` header on the measurement, TURN credential and results-logging requests. Obtain it from your own backend — the engine never requests one itself. Not sent over plain HTTP unless `allowInsecureAuthorizationToken` is set. | `null` |
-| **allowInsecureAuthorizationToken**: *boolean* | Sends `authorizationToken` even when the endpoint is not HTTPS, for local development against an `http://` server. Never enable this in production: the server treats a token seen over plaintext as compromised and revokes it. | `false` |
+| **authorizationToken**: *string* | 🧪 *Experimental.* An opaque token attributing the test to a registered customer, sent as an `Authorization: Bearer` header on the measurement, TURN credential and results-logging requests. Obtain it from your own backend — the engine never requests one itself. Requires `authorizationEnabled`; on its own it is never sent. Not sent over plain HTTP unless `allowInsecureAuthorizationToken` is set. | `null` |
+| **authorizationEnabled**: *`'header'` \| boolean* | 🧪 *Experimental.* Opts in to sending `authorizationToken`, which is otherwise withheld even when set. `'header'` and `true` both send it as `Authorization: Bearer`; `true` is a permanent alias for `'header'`, so a future transport can be added without changing what an existing config does. | `undefined` |
+| **allowInsecureAuthorizationToken**: *boolean* | 🧪 *Experimental.* Sends `authorizationToken` even when the endpoint is not HTTPS, for local development against an `http://` server. Never enable this in production: the server treats a token seen over plaintext as compromised and revokes it. | `false` |
 | **measurements**: *array* | The sequence of measurements to perform by the speedtest engine. See [below](#measurement-config) for the specific syntax of this option. ||
 | **measureDownloadLoadedLatency**: *boolean* | Whether to perform additional latency measurements simultaneously with download requests, to measure loaded latency (during download). | `true` |
 | **measureUploadLoadedLatency**: *boolean* | Whether to perform additional latency measurements simultaneously with upload requests, to measure loaded latency (during upload). | `true` |

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -73,6 +73,14 @@ export interface Config {
    * results-logging requests. Not sent over plain HTTP. Default: `null`.
    */
   authorizationToken: string | null;
+  /**
+   * Sends {@link authorizationToken} even when the endpoint is not HTTPS, for
+   * local development against an `http://` server.
+   *
+   * Never enable this in production: the server treats a token seen over
+   * plaintext as compromised and revokes it. Default: `false`.
+   */
+  allowInsecureAuthorizationToken: boolean;
 
   /**
    * Ordered list of measurement phases to execute.
@@ -147,6 +155,7 @@ const defaultConfig: Config = {
   includeCredentials: false,
   sessionId: undefined,
   authorizationToken: null,
+  allowInsecureAuthorizationToken: false,
 
   // Measurements
   measurements: [

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -68,8 +68,8 @@ export interface Config {
   /** Optional session ID attached to measurement logs. */
   sessionId: string | undefined;
   /**
-   * Opaque token attributing this test to a registered customer, sent as a
-   * `jwt` query-string param on the measurement, TURN credential and
+   * Opaque token attributing this test to a registered customer, sent as an
+   * `Authorization: Bearer` header on the measurement, TURN credential and
    * results-logging requests. Not sent over plain HTTP. Default: `null`.
    */
   authorizationToken: string | null;

--- a/src/config/defaultConfig.ts
+++ b/src/config/defaultConfig.ts
@@ -70,15 +70,32 @@ export interface Config {
   /**
    * Opaque token attributing this test to a registered customer, sent as an
    * `Authorization: Bearer` header on the measurement, TURN credential and
-   * results-logging requests. Not sent over plain HTTP. Default: `null`.
+   * results-logging requests. Requires {@link authorizationEnabled}; on its own
+   * it is never sent. Not sent over plain HTTP. Default: `null`.
+   *
+   * @experimental Unstable — may change or be removed in any release.
    */
   authorizationToken: string | null;
+  /**
+   * Opts in to sending {@link authorizationToken}, which is otherwise withheld
+   * even when set.
+   *
+   * `'header'` and `true` both send it as `Authorization: Bearer`; `true` is a
+   * permanent alias for `'header'`, so a future transport can be added without
+   * changing what an existing config does. `false` and `undefined` send
+   * nothing. Default: `undefined`.
+   *
+   * @experimental Unstable — may change or be removed in any release.
+   */
+  authorizationEnabled: 'header' | boolean | undefined;
   /**
    * Sends {@link authorizationToken} even when the endpoint is not HTTPS, for
    * local development against an `http://` server.
    *
    * Never enable this in production: the server treats a token seen over
    * plaintext as compromised and revokes it. Default: `false`.
+   *
+   * @experimental Unstable — may change or be removed in any release.
    */
   allowInsecureAuthorizationToken: boolean;
 
@@ -155,6 +172,7 @@ const defaultConfig: Config = {
   includeCredentials: false,
   sessionId: undefined,
   authorizationToken: null,
+  authorizationEnabled: undefined,
   allowInsecureAuthorizationToken: false,
 
   // Measurements

--- a/src/engines/BandwidthEngine/BandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/BandwidthEngine.ts
@@ -1,5 +1,5 @@
 import type { Engine } from '../Engine';
-import { redactAuthorizationToken } from '../../utils/authorization';
+import { withAuthorizationHeader } from '../../utils/authorization';
 
 const MAX_RETRIES = 20;
 
@@ -129,6 +129,7 @@ export interface BandwidthEngineOptions {
   throttleMs?: number;
   estimatedServerTime?: number;
   serverTimeDelta?: number;
+  authorizationToken?: string | null;
 }
 
 /**
@@ -145,7 +146,8 @@ class BandwidthMeasurementEngine implements Engine {
       uploadApiUrl,
       throttleMs = 0,
       estimatedServerTime = 0,
-      serverTimeDelta = 0
+      serverTimeDelta = 0,
+      authorizationToken = null
     }: BandwidthEngineOptions = {}
   ) {
     if (!measurements) throw new Error('Missing measurements argument');
@@ -158,6 +160,7 @@ class BandwidthMeasurementEngine implements Engine {
     this.#throttleMs = throttleMs;
     this.#estimatedServerTime = Math.max(0, estimatedServerTime);
     this.#serverTimeDelta = Math.max(0, serverTimeDelta);
+    this.#authorizationToken = authorizationToken;
   }
 
   // Public attributes
@@ -257,6 +260,7 @@ class BandwidthMeasurementEngine implements Engine {
   #throttleMs: number = 0;
   #estimatedServerTime: number = 0;
   #serverTimeDelta: number = 0;
+  #authorizationToken: string | null = null;
 
   /**
    * Aborts the current measurement.
@@ -375,15 +379,19 @@ class BandwidthMeasurementEngine implements Engine {
     Object.entries(qsParams).forEach(([k, v]) => urlObj.searchParams.set(k, v));
     const url = urlObj.href;
 
-    const fetchOpt: RequestInit = Object.assign(
-      {},
-      isDown
-        ? {}
-        : {
-            method: 'POST',
-            body: genContent(numBytes)
-          },
-      this.#fetchOptions
+    const fetchOpt: RequestInit = withAuthorizationHeader(
+      Object.assign(
+        {},
+        isDown
+          ? {}
+          : {
+              method: 'POST',
+              body: genContent(numBytes)
+            },
+        this.#fetchOptions
+      ),
+      this.#authorizationToken,
+      url
     );
 
     if (this.#retries === 0) {
@@ -554,8 +562,7 @@ class BandwidthMeasurementEngine implements Engine {
         if (this.#currentAbortController!.signal.aborted) {
           return;
         }
-        const safeUrl = redactAuthorizationToken(url);
-        console.warn(`Error fetching ${safeUrl}: ${error}`);
+        console.warn(`Error fetching ${url}: ${error}`);
 
         if (this.#retries++ < MAX_RETRIES) {
           this.#nextMeasurement(); // keep trying
@@ -563,7 +570,7 @@ class BandwidthMeasurementEngine implements Engine {
           this.#retries = 0;
           this.#setRunning(false);
           this.#onConnectionError(
-            `Connection failed to ${safeUrl}. Gave up after ${MAX_RETRIES} retries.`
+            `Connection failed to ${url}. Gave up after ${MAX_RETRIES} retries.`
           );
         }
       });

--- a/src/engines/BandwidthEngine/BandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/BandwidthEngine.ts
@@ -1,5 +1,8 @@
 import type { Engine } from '../Engine';
-import { withAuthorizationHeader } from '../../utils/authorization';
+import {
+  withAuthorizationHeader,
+  type AuthorizationOptions
+} from '../../utils/authorization';
 
 const MAX_RETRIES = 20;
 
@@ -129,7 +132,7 @@ export interface BandwidthEngineOptions {
   throttleMs?: number;
   estimatedServerTime?: number;
   serverTimeDelta?: number;
-  authorizationToken?: string | null;
+  authorization?: AuthorizationOptions | null;
 }
 
 /**
@@ -147,7 +150,7 @@ class BandwidthMeasurementEngine implements Engine {
       throttleMs = 0,
       estimatedServerTime = 0,
       serverTimeDelta = 0,
-      authorizationToken = null
+      authorization = null
     }: BandwidthEngineOptions = {}
   ) {
     if (!measurements) throw new Error('Missing measurements argument');
@@ -160,7 +163,7 @@ class BandwidthMeasurementEngine implements Engine {
     this.#throttleMs = throttleMs;
     this.#estimatedServerTime = Math.max(0, estimatedServerTime);
     this.#serverTimeDelta = Math.max(0, serverTimeDelta);
-    this.#authorizationToken = authorizationToken;
+    this.#authorization = authorization;
   }
 
   // Public attributes
@@ -260,7 +263,7 @@ class BandwidthMeasurementEngine implements Engine {
   #throttleMs: number = 0;
   #estimatedServerTime: number = 0;
   #serverTimeDelta: number = 0;
-  #authorizationToken: string | null = null;
+  #authorization: AuthorizationOptions | null = null;
 
   /**
    * Aborts the current measurement.
@@ -390,7 +393,7 @@ class BandwidthMeasurementEngine implements Engine {
             },
         this.#fetchOptions
       ),
-      this.#authorizationToken,
+      this.#authorization,
       url
     );
 

--- a/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
@@ -30,16 +30,17 @@ class LoggingBandwidthEngine extends BandwidthEngine {
       measurementId,
       logApiUrl,
       sessionId,
+      authorization,
       ...ptProps
     }: LoggingBandwidthEngineOptions = {}
   ) {
-    super(measurements, ptProps);
+    // Destructured out of `ptProps`, so it has to be passed back explicitly.
+    super(measurements, { ...ptProps, authorization });
 
     this.#measurementId = measurementId;
     this.#logApiUrl = logApiUrl;
     this.#sessionId = sessionId;
-    // Read without destructuring, so `super` receives it too.
-    this.#authorization = ptProps.authorization ?? null;
+    this.#authorization = authorization ?? null;
 
     super.qsParams = logApiUrl ? { measId: this.#measurementId! } : {};
     super.responseHook = (r: ResponseHookPayload) =>

--- a/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
@@ -6,6 +6,7 @@ import type {
   ResponseHookPayload
 } from './BandwidthEngine';
 import type { ParallelLatencyOptions } from './ParallelLatency';
+import { withAuthorizationHeader } from '../../utils/authorization';
 
 export interface LoggingBandwidthEngineOptions extends ParallelLatencyOptions {
   measurementId?: string;
@@ -34,6 +35,8 @@ class LoggingBandwidthEngine extends BandwidthEngine {
     this.#measurementId = measurementId;
     this.#logApiUrl = logApiUrl;
     this.#sessionId = sessionId;
+    // Read without destructuring, so `super` receives it too.
+    this.#authorizationToken = ptProps.authorizationToken ?? null;
 
     super.qsParams = logApiUrl ? { measId: this.#measurementId! } : {};
     super.responseHook = (r: ResponseHookPayload) =>
@@ -77,6 +80,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
   #requestTime: number | null | undefined;
   #logApiUrl: string | undefined;
   #sessionId: string | undefined;
+  #authorizationToken: string | null;
 
   // Internal methods
   #loggingResponseHook(r: ResponseHookPayload): void {
@@ -110,13 +114,21 @@ class LoggingBandwidthEngine extends BandwidthEngine {
     this.#token = null;
     this.#requestTime = null;
 
-    // Swallowed: logging is best-effort, and an unhandled rejection would print
-    // the URL, which carries the authorization token.
-    fetch(this.#logApiUrl, {
-      method: 'POST',
-      body: JSON.stringify(logData),
-      ...this.fetchOptions
-    }).catch(() => {});
+    // Swallowed: logging is best-effort and must never surface as a test error.
+    fetch(
+      this.#logApiUrl,
+      // Resolved against the log URL, not the measurement URL the inherited
+      // fetchOptions were built for — the two may not share a scheme.
+      withAuthorizationHeader(
+        {
+          method: 'POST',
+          body: JSON.stringify(logData),
+          ...this.fetchOptions
+        },
+        this.#authorizationToken,
+        this.#logApiUrl
+      )
+    ).catch(() => {});
   }
 }
 

--- a/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
@@ -6,7 +6,10 @@ import type {
   ResponseHookPayload
 } from './BandwidthEngine';
 import type { ParallelLatencyOptions } from './ParallelLatency';
-import { withAuthorizationHeader } from '../../utils/authorization';
+import {
+  withAuthorizationHeader,
+  type AuthorizationOptions
+} from '../../utils/authorization';
 
 export interface LoggingBandwidthEngineOptions extends ParallelLatencyOptions {
   measurementId?: string;
@@ -36,7 +39,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
     this.#logApiUrl = logApiUrl;
     this.#sessionId = sessionId;
     // Read without destructuring, so `super` receives it too.
-    this.#authorizationToken = ptProps.authorizationToken ?? null;
+    this.#authorization = ptProps.authorization ?? null;
 
     super.qsParams = logApiUrl ? { measId: this.#measurementId! } : {};
     super.responseHook = (r: ResponseHookPayload) =>
@@ -80,7 +83,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
   #requestTime: number | null | undefined;
   #logApiUrl: string | undefined;
   #sessionId: string | undefined;
-  #authorizationToken: string | null;
+  #authorization: AuthorizationOptions | null;
 
   // Internal methods
   #loggingResponseHook(r: ResponseHookPayload): void {
@@ -125,7 +128,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
           body: JSON.stringify(logData),
           ...this.fetchOptions
         },
-        this.#authorizationToken,
+        this.#authorization,
         this.#logApiUrl
       )
     ).catch(() => {});

--- a/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
+++ b/src/engines/BandwidthEngine/LoggingBandwidthEngine.ts
@@ -118,7 +118,7 @@ class LoggingBandwidthEngine extends BandwidthEngine {
     this.#token = null;
     this.#requestTime = null;
 
-    // Swallowed: logging is best-effort and must never surface as a test error.
+    // Swallowed: a failed log must not fail the measurement it describes.
     fetch(
       this.#logApiUrl,
       // Resolved against the log URL, not the measurement URL the inherited

--- a/src/engines/BandwidthEngine/ParallelLatency.ts
+++ b/src/engines/BandwidthEngine/ParallelLatency.ts
@@ -26,7 +26,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
       uploadApiUrl,
       estimatedServerTime = 0,
       serverTimeDelta = 0,
-      authorizationToken = null,
+      authorization = null,
       ...ptProps
     }: ParallelLatencyOptions = {}
   ) {
@@ -35,7 +35,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
       uploadApiUrl,
       estimatedServerTime,
       serverTimeDelta,
-      authorizationToken,
+      authorization,
       ...ptProps
     });
 
@@ -54,7 +54,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
           uploadApiUrl,
           estimatedServerTime,
           serverTimeDelta,
-          authorizationToken,
+          authorization,
           throttleMs: parallelLatencyThrottleMs
         }
       );

--- a/src/engines/BandwidthEngine/ParallelLatency.ts
+++ b/src/engines/BandwidthEngine/ParallelLatency.ts
@@ -26,6 +26,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
       uploadApiUrl,
       estimatedServerTime = 0,
       serverTimeDelta = 0,
+      authorizationToken = null,
       ...ptProps
     }: ParallelLatencyOptions = {}
   ) {
@@ -34,6 +35,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
       uploadApiUrl,
       estimatedServerTime,
       serverTimeDelta,
+      authorizationToken,
       ...ptProps
     });
 
@@ -52,6 +54,7 @@ class BandwidthWithParallelLatencyEngine extends BandwidthEngine {
           uploadApiUrl,
           estimatedServerTime,
           serverTimeDelta,
+          authorizationToken,
           throttleMs: parallelLatencyThrottleMs
         }
       );

--- a/src/engines/LoadNetworkEngine/index.ts
+++ b/src/engines/LoadNetworkEngine/index.ts
@@ -1,3 +1,8 @@
+import {
+  withAuthorizationHeader,
+  type AuthorizationOptions
+} from '../../utils/authorization';
+
 interface LoadEngineConfig {
   apiUrl: string;
   qsParams?: Record<string, string>;
@@ -73,6 +78,7 @@ export interface LoadNetworkUploadConfig {
 export interface LoadNetworkEngineOptions {
   download?: LoadNetworkDownloadConfig | null;
   upload?: LoadNetworkUploadConfig | null;
+  authorization?: AuthorizationOptions | null;
 }
 
 /**
@@ -81,7 +87,11 @@ export interface LoadNetworkEngineOptions {
  * engines to saturate the connection during measurements.
  */
 class LoadNetworkEngine {
-  constructor({ download, upload }: LoadNetworkEngineOptions = {}) {
+  constructor({
+    download,
+    upload,
+    authorization = null
+  }: LoadNetworkEngineOptions = {}) {
     // Expected attrs for each: { apiUrl, chunkSize }
     if (!download && !upload)
       throw new Error('Missing at least one of download/upload config');
@@ -131,7 +141,10 @@ class LoadNetworkEngine {
           this.fetchOptions
         );
 
-        return fetch(url, fetchOpt)
+        // These saturate the same measurement endpoints as a real measurement,
+        // so they carry the token too — otherwise the heaviest traffic in a
+        // test goes unattributed.
+        return fetch(url, withAuthorizationHeader(fetchOpt, authorization, url))
           .then(r => {
             if (r.ok) return r;
             throw Error(r.statusText);

--- a/src/engines/PacketLossEngine/PacketLossEngine.ts
+++ b/src/engines/PacketLossEngine/PacketLossEngine.ts
@@ -1,7 +1,10 @@
 import SelfWebRtcDataConnection from './SelfWebRtcDataConnection';
 import type { Engine } from '../Engine';
 import type { PacketLossResults } from '../../types';
-import { withAuthorizationHeader } from '../../utils/authorization';
+import {
+  withAuthorizationHeader,
+  type AuthorizationOptions
+} from '../../utils/authorization';
 
 export type { PacketLossResults };
 
@@ -28,7 +31,7 @@ export interface PacketLossEngineOptions {
   turnServerCredsApiIncludeCredentials?: boolean;
   turnServerUser?: string;
   turnServerPass?: string;
-  authorizationToken?: string | null;
+  authorization?: AuthorizationOptions | null;
   numMsgs?: number;
   batchSize?: number;
   batchWaitTime?: number;
@@ -58,7 +61,7 @@ export default class PacketLossEngine implements Engine {
     turnServerCredsApiIncludeCredentials = false,
     turnServerUser,
     turnServerPass,
-    authorizationToken = null,
+    authorization = null,
     numMsgs = 100,
     batchSize = 10,
     batchWaitTime = 10, // ms (in between batches)
@@ -85,7 +88,7 @@ export default class PacketLossEngine implements Engine {
                 ? 'include'
                 : undefined
             },
-            authorizationToken,
+            authorization,
             turnServerCredsApi
           )
         )

--- a/src/engines/PacketLossEngine/PacketLossEngine.ts
+++ b/src/engines/PacketLossEngine/PacketLossEngine.ts
@@ -1,6 +1,7 @@
 import SelfWebRtcDataConnection from './SelfWebRtcDataConnection';
 import type { Engine } from '../Engine';
 import type { PacketLossResults } from '../../types';
+import { withAuthorizationHeader } from '../../utils/authorization';
 
 export type { PacketLossResults };
 
@@ -27,6 +28,7 @@ export interface PacketLossEngineOptions {
   turnServerCredsApiIncludeCredentials?: boolean;
   turnServerUser?: string;
   turnServerPass?: string;
+  authorizationToken?: string | null;
   numMsgs?: number;
   batchSize?: number;
   batchWaitTime?: number;
@@ -56,6 +58,7 @@ export default class PacketLossEngine implements Engine {
     turnServerCredsApiIncludeCredentials = false,
     turnServerUser,
     turnServerPass,
+    authorizationToken = null,
     numMsgs = 100,
     batchSize = 10,
     batchWaitTime = 10, // ms (in between batches)
@@ -74,11 +77,18 @@ export default class PacketLossEngine implements Engine {
 
     (!turnServerUser || !turnServerPass
       ? // Get TURN credentials from API endpoint if not statically supplied
-        fetch(turnServerCredsApi!, {
-          credentials: turnServerCredsApiIncludeCredentials
-            ? 'include'
-            : undefined
-        })
+        fetch(
+          turnServerCredsApi!,
+          withAuthorizationHeader(
+            {
+              credentials: turnServerCredsApiIncludeCredentials
+                ? 'include'
+                : undefined
+            },
+            authorizationToken,
+            turnServerCredsApi
+          )
+        )
           .then(r => r.json())
           .then((d: TurnServerCredsApiResult) => {
             if (d.error) throw d.error;

--- a/src/engines/PacketLossEngine/PacketLossEngine.ts
+++ b/src/engines/PacketLossEngine/PacketLossEngine.ts
@@ -83,11 +83,9 @@ export default class PacketLossEngine implements Engine {
         fetch(
           turnServerCredsApi!,
           withAuthorizationHeader(
-            {
-              credentials: turnServerCredsApiIncludeCredentials
-                ? 'include'
-                : undefined
-            },
+            turnServerCredsApiIncludeCredentials
+              ? { credentials: 'include' }
+              : {},
             authorization,
             turnServerCredsApi
           )

--- a/src/engines/PacketLossEngine/UnderLoad.ts
+++ b/src/engines/PacketLossEngine/UnderLoad.ts
@@ -23,9 +23,11 @@ class PacketLossUnderLoadEngine extends PacketLossEngine {
     uploadChunkSize,
     downloadApiUrl,
     uploadApiUrl,
+    authorization,
     ...ptProps
   }: PacketLossUnderLoadOptions = {}) {
-    super(ptProps);
+    // Destructured out of `ptProps`, so it has to be passed back explicitly.
+    super({ ...ptProps, authorization });
 
     if (downloadChunkSize || uploadChunkSize) {
       this.#loadEngine = new LoadNetworkEngine({
@@ -40,7 +42,8 @@ class PacketLossUnderLoadEngine extends PacketLossEngine {
               apiUrl: uploadApiUrl!,
               chunkSize: uploadChunkSize
             }
-          : null
+          : null,
+        authorization
       });
 
       super.onCredentialsFailure =

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,13 @@ class MeasurementEngine {
       userConfig,
       internalConfig
     ) as SpeedTestConfig;
+    // Built once: the insecure-transport warning is latched per object, so a
+    // fresh one per access would warn on every request.
+    this.#authorization = {
+      token: this.#config.authorizationToken,
+      enabled: this.#config.authorizationEnabled,
+      allowInsecure: this.#config.allowInsecureAuthorizationToken
+    };
     this.#results = new Results(this.#config);
     this.#config.autoStart && this.play();
   }
@@ -144,10 +151,7 @@ class MeasurementEngine {
 
   /** The token and its transport policy, as one unit for the sub-engines. */
   protected get authorization(): AuthorizationOptions {
-    return {
-      token: this.#config.authorizationToken,
-      allowInsecure: this.#config.allowInsecureAuthorizationToken
-    };
+    return this.#authorization;
   }
 
   /** Not paused and not finished. */
@@ -216,6 +220,7 @@ class MeasurementEngine {
 
   // Internal state
   readonly #config: SpeedTestConfig;
+  readonly #authorization: AuthorizationOptions;
   readonly #results: Results;
 
   #measurementId: string = genMeasId();
@@ -519,9 +524,9 @@ class MeasurementEngine {
         ) as Engine;
         (
           engine as Engine & { fetchOptions: Record<string, unknown> }
-        ).fetchOptions = {
-          credentials: this.#config.includeCredentials ? 'include' : undefined
-        };
+        ).fetchOptions = this.#config.includeCredentials
+          ? { credentials: 'include' }
+          : {};
         (
           engine as Engine & { abortRequestDuration: number }
         ).abortRequestDuration = this.#config.bandwidthAbortRequestDuration;
@@ -600,9 +605,9 @@ class MeasurementEngine {
           ) as Engine;
           (
             engine as Engine & { fetchOptions: Record<string, unknown> }
-          ).fetchOptions = {
-            credentials: this.#config.includeCredentials ? 'include' : undefined
-          };
+          ).fetchOptions = this.#config.includeCredentials
+            ? { credentials: 'include' }
+            : {};
           (
             engine as Engine & { finishRequestDuration: number }
           ).finishRequestDuration = this.#config.bandwidthFinishRequestDuration;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import Results from './Results';
 import logFinalResults, {
   type AimLogResponse
 } from './logging/logFinalResults';
+import type { AuthorizationOptions } from './utils/authorization';
 
 const DEFAULT_OPTIMAL_DOWNLOAD_SIZE = 1e6;
 const DEFAULT_OPTIMAL_UPLOAD_SIZE = 1e6;
@@ -139,6 +140,14 @@ class MeasurementEngine {
   /** The merged config, so subclasses need not rebuild it. */
   protected get config(): SpeedTestConfig {
     return this.#config;
+  }
+
+  /** The token and its transport policy, as one unit for the sub-engines. */
+  protected get authorization(): AuthorizationOptions {
+    return {
+      token: this.#config.authorizationToken,
+      allowInsecure: this.#config.allowInsecureAuthorizationToken
+    };
   }
 
   /** Not paused and not finished. */
@@ -428,7 +437,7 @@ class MeasurementEngine {
             turnServerCredsApiIncludeCredentials: includeCredentials,
             turnServerUser: turnServerUser ?? undefined,
             turnServerPass: turnServerPass ?? undefined,
-            authorizationToken: this.#config.authorizationToken,
+            authorization: this.authorization,
             numMsgs,
 
             // if under load
@@ -497,7 +506,7 @@ class MeasurementEngine {
             logApiUrl: this.#config.logMeasurementApiUrl ?? undefined,
             measurementId: this.#measurementId,
             sessionId: this.#config.sessionId,
-            authorizationToken: this.#config.authorizationToken,
+            authorization: this.authorization,
 
             // if under load
             downloadChunkSize: msmConfig.loadDown
@@ -586,7 +595,7 @@ class MeasurementEngine {
               measureParallelLatency,
               parallelLatencyThrottleMs: this.#config.loadedLatencyThrottle,
               sessionId: this.#config.sessionId,
-              authorizationToken: this.#config.authorizationToken
+              authorization: this.authorization
             }
           ) as Engine;
           (
@@ -780,7 +789,7 @@ class SpeedTestEngine extends MeasurementEngine {
     logFinalResults(results, {
       apiUrl,
       sessionId: this.config.sessionId,
-      authorizationToken: this.config.authorizationToken
+      authorization: this.authorization
     }).then(response => {
       this.onResultsLogged(response);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import Results from './Results';
 import logFinalResults, {
   type AimLogResponse
 } from './logging/logFinalResults';
-import { applyAuthorizationToken } from './utils/authorization';
 
 const DEFAULT_OPTIMAL_DOWNLOAD_SIZE = 1e6;
 const DEFAULT_OPTIMAL_UPLOAD_SIZE = 1e6;
@@ -123,14 +122,12 @@ const genMeasId = (): string => `${Math.round(Math.random() * 1e16)}`;
  */
 class MeasurementEngine {
   constructor(userConfig: ConfigOptions = {}) {
-    this.#config = applyAuthorizationToken(
-      Object.assign(
-        {},
-        defaultConfig,
-        userConfig,
-        internalConfig
-      ) as SpeedTestConfig
-    );
+    this.#config = Object.assign(
+      {},
+      defaultConfig,
+      userConfig,
+      internalConfig
+    ) as SpeedTestConfig;
     this.#results = new Results(this.#config);
     this.#config.autoStart && this.play();
   }
@@ -431,6 +428,7 @@ class MeasurementEngine {
             turnServerCredsApiIncludeCredentials: includeCredentials,
             turnServerUser: turnServerUser ?? undefined,
             turnServerPass: turnServerPass ?? undefined,
+            authorizationToken: this.#config.authorizationToken,
             numMsgs,
 
             // if under load
@@ -499,6 +497,7 @@ class MeasurementEngine {
             logApiUrl: this.#config.logMeasurementApiUrl ?? undefined,
             measurementId: this.#measurementId,
             sessionId: this.#config.sessionId,
+            authorizationToken: this.#config.authorizationToken,
 
             // if under load
             downloadChunkSize: msmConfig.loadDown
@@ -586,7 +585,8 @@ class MeasurementEngine {
               measurementId: this.#measurementId,
               measureParallelLatency,
               parallelLatencyThrottleMs: this.#config.loadedLatencyThrottle,
-              sessionId: this.#config.sessionId
+              sessionId: this.#config.sessionId,
+              authorizationToken: this.#config.authorizationToken
             }
           ) as Engine;
           (
@@ -779,7 +779,8 @@ class SpeedTestEngine extends MeasurementEngine {
     }
     logFinalResults(results, {
       apiUrl,
-      sessionId: this.config.sessionId
+      sessionId: this.config.sessionId,
+      authorizationToken: this.config.authorizationToken
     }).then(response => {
       this.onResultsLogged(response);
     });

--- a/src/logging/logFinalResults.ts
+++ b/src/logging/logFinalResults.ts
@@ -1,6 +1,9 @@
 import type Results from '../Results';
 import type { BandwidthPoint } from '../types';
-import { withAuthorizationHeader } from '../utils/authorization';
+import {
+  withAuthorizationHeader,
+  type AuthorizationOptions
+} from '../utils/authorization';
 
 /** Subset of PacketLossResults used for logging (includes error case). */
 interface PacketLossDetails {
@@ -28,7 +31,7 @@ interface LogConfig {
   /** Session ID to include in the log payload. */
   sessionId: string | undefined;
   /** Token attributing this test, sent as an `Authorization` header. */
-  authorizationToken: string | null;
+  authorization: AuthorizationOptions | null;
 }
 
 /** Payload structure sent to the AIM logging endpoint. */
@@ -108,7 +111,7 @@ const scoreParser = (
  */
 const logAimResults = async (
   results: Results,
-  { apiUrl, sessionId, authorizationToken }: LogConfig
+  { apiUrl, sessionId, authorization }: LogConfig
 ): Promise<AimLogResponse> => {
   const logData: LogData = {
     sessionId
@@ -141,7 +144,7 @@ const logAimResults = async (
           method: 'POST',
           body: JSON.stringify(logData)
         },
-        authorizationToken,
+        authorization,
         apiUrl
       )
     );

--- a/src/logging/logFinalResults.ts
+++ b/src/logging/logFinalResults.ts
@@ -1,5 +1,6 @@
 import type Results from '../Results';
 import type { BandwidthPoint } from '../types';
+import { withAuthorizationHeader } from '../utils/authorization';
 
 /** Subset of PacketLossResults used for logging (includes error case). */
 interface PacketLossDetails {
@@ -26,6 +27,8 @@ interface LogConfig {
   apiUrl: string;
   /** Session ID to include in the log payload. */
   sessionId: string | undefined;
+  /** Token attributing this test, sent as an `Authorization` header. */
+  authorizationToken: string | null;
 }
 
 /** Payload structure sent to the AIM logging endpoint. */
@@ -105,7 +108,7 @@ const scoreParser = (
  */
 const logAimResults = async (
   results: Results,
-  { apiUrl, sessionId }: LogConfig
+  { apiUrl, sessionId, authorizationToken }: LogConfig
 ): Promise<AimLogResponse> => {
   const logData: LogData = {
     sessionId
@@ -131,10 +134,17 @@ const logAimResults = async (
   console.log('results', logData);
 
   try {
-    const response = await fetch(apiUrl, {
-      method: 'POST',
-      body: JSON.stringify(logData)
-    });
+    const response = await fetch(
+      apiUrl,
+      withAuthorizationHeader(
+        {
+          method: 'POST',
+          body: JSON.stringify(logData)
+        },
+        authorizationToken,
+        apiUrl
+      )
+    );
     if (!response.ok) {
       return { requestId: undefined };
     }

--- a/src/utils/authorization.ts
+++ b/src/utils/authorization.ts
@@ -1,103 +1,43 @@
 /**
- * Query-string parameter carrying the authorization token.
- *
- * Named `jwt`, not `token`: the measurement log POST body already has a
- * `token` field holding a server-issued per-measurement value, and both are
- * sent to `logMeasurementApiUrl`.
+ * Whether `apiUrl` resolves to an HTTPS endpoint. Relative URLs inherit the
+ * page origin, so they can only be resolved inside a browser; anything we
+ * cannot resolve is treated as insecure.
  */
-export const AUTHORIZATION_TOKEN_PARAM = 'jwt';
-
-/** Placeholder substituted for the token in error messages. */
-const REDACTED = 'REDACTED';
-
-/**
- * Appends the authorization token to `apiUrl`, preserving existing params.
- *
- * Query string rather than a header, which would trigger a CORS preflight and
- * suppress BandwidthEngine's server-time calibration. Never over plain HTTP.
- */
-export const withAuthorizationToken = (
-  apiUrl: string,
-  token: string | null
-): string => {
-  if (!token) return apiUrl;
-
-  // Only relative URLs need the page origin, so absolute ones work without a DOM.
-  let urlObj: URL;
+const isSecureApiUrl = (apiUrl: string): boolean => {
   try {
-    urlObj = new URL(apiUrl);
-  } catch {
-    urlObj = new URL(apiUrl, window.location.origin);
-  }
-
-  if (urlObj.protocol !== 'https:') return apiUrl;
-
-  urlObj.searchParams.set(AUTHORIZATION_TOKEN_PARAM, token);
-  return urlObj.href;
-};
-
-/**
- * Masks the authorization token in a URL bound for a log or an error callback.
- *
- * Consumers routinely forward `onError` payloads to third-party log sinks, so
- * the credential must not travel with them. Returns `apiUrl` untouched when
- * there is no token to mask.
- */
-export const redactAuthorizationToken = (apiUrl: string): string => {
-  let urlObj: URL;
-  try {
-    urlObj = new URL(apiUrl);
+    return new URL(apiUrl).protocol === 'https:';
   } catch {
     try {
-      urlObj = new URL(apiUrl, window.location.origin);
+      return new URL(apiUrl, window.location.origin).protocol === 'https:';
     } catch {
-      return apiUrl;
+      return false;
     }
   }
-
-  if (!urlObj.searchParams.has(AUTHORIZATION_TOKEN_PARAM)) return apiUrl;
-
-  urlObj.searchParams.set(AUTHORIZATION_TOKEN_PARAM, REDACTED);
-  return urlObj.href;
 };
 
 /**
- * Config URLs that carry the authorization token. Single source of truth: a new
- * measurement endpoint must be added here to be attributed.
+ * Merges the `Authorization: Bearer <token>` header for `apiUrl` into `init`,
+ * preserving any headers the caller already set. Returns `init` untouched when
+ * there is no token, or when the token must not be sent to `apiUrl`.
  *
- * `turnServerUri` is excluded (not HTTP), as are the reachability, RPKI and
- * NXDOMAIN probe hosts, which are unrelated to the measurement endpoints.
+ * A header rather than a query-string param: request URLs are routinely
+ * persisted in server-side logs, traces and error reports, so a bearer
+ * credential must not travel in one. Applied to the measurement (`__down`,
+ * `__up`), TURN credential and logging endpoints — the reachability, RPKI and
+ * NXDOMAIN probe hosts are unrelated and never receive it.
+ *
+ * Resolved per target URL rather than once per engine, because a single config
+ * may mix schemes: the token is never sent over plain HTTP, where an observer
+ * could lift it and the server treats it as compromised.
  */
-export const AUTHORIZABLE_URLS = [
-  'downloadApiUrl',
-  'uploadApiUrl',
-  'turnServerCredsApiUrl',
-  'logAimApiUrl',
-  'logMeasurementApiUrl'
-] as const;
+export const withAuthorizationHeader = (
+  init: RequestInit,
+  token: string | null | undefined,
+  apiUrl: string | null | undefined
+): RequestInit => {
+  if (!token || !apiUrl || !isSecureApiUrl(apiUrl)) return init;
 
-/** The config fields {@link applyAuthorizationToken} rewrites. */
-type AuthorizableUrls = { authorizationToken: string | null } & {
-  [K in (typeof AUTHORIZABLE_URLS)[number]]: string | null;
-};
-
-/**
- * Attaches the token to every URL in {@link AUTHORIZABLE_URLS}, so the engines
- * inherit it through the URLs they already receive. Mutates `config`, which is
- * always a freshly merged object.
- */
-export const applyAuthorizationToken = <T extends AuthorizableUrls>(
-  config: T
-): T => {
-  const token = config.authorizationToken;
-  if (!token) return config;
-
-  // Widened to write through the union of keys; T only narrows the field types.
-  const urls = config as AuthorizableUrls;
-  for (const key of AUTHORIZABLE_URLS) {
-    const url = urls[key];
-    if (url) urls[key] = withAuthorizationToken(url, token);
-  }
-
-  return config;
+  const headers = new Headers(init.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  return { ...init, headers };
 };

--- a/src/utils/authorization.ts
+++ b/src/utils/authorization.ts
@@ -1,10 +1,12 @@
 /**
- * The token and the single policy decision that governs it, passed as one unit
- * so a transport change touches this module instead of every call site.
+ * The token and the policy decisions that govern it, passed as one unit so a
+ * transport change touches this module instead of every call site.
  */
 export interface AuthorizationOptions {
   /** See config `authorizationToken`. */
   token: string | null;
+  /** See config `authorizationEnabled`. */
+  enabled: 'header' | boolean | undefined;
   /** See config `allowInsecureAuthorizationToken`. */
   allowInsecure: boolean;
 }
@@ -26,12 +28,15 @@ const isSecureApiUrl = (apiUrl: string): boolean => {
   }
 };
 
-/** Latched: a test issues hundreds of requests, and one warning is enough. */
-let warnedInsecure = false;
+/**
+ * Latched per options object — which is one per engine — so a run warns once
+ * rather than once per request, and a second run warns again.
+ */
+const warnedInsecure = new WeakSet<AuthorizationOptions>();
 
-const warnInsecureOnce = (): void => {
-  if (warnedInsecure) return;
-  warnedInsecure = true;
+const warnInsecureOnce = (authorization: AuthorizationOptions): void => {
+  if (warnedInsecure.has(authorization)) return;
+  warnedInsecure.add(authorization);
   console.warn(
     'Sending the authorization token to an endpoint that is not known to be ' +
       'secure, because allowInsecureAuthorizationToken is enabled. Do not ' +
@@ -42,8 +47,9 @@ const warnInsecureOnce = (): void => {
 
 /**
  * Merges the `Authorization: Bearer <token>` header for `apiUrl` into `init`,
- * preserving any headers the caller already set. Returns `init` untouched when
- * there is no token, or when the token must not be sent to `apiUrl`.
+ * preserving any headers the caller already set. Returns `init` untouched
+ * unless a token exists, `enabled` opts in, and the token may be sent to
+ * `apiUrl`.
  *
  * A header rather than a query-string param: request URLs are routinely
  * persisted in server-side logs, traces and error reports, so a bearer
@@ -61,14 +67,18 @@ export const withAuthorizationHeader = (
   authorization: AuthorizationOptions | null | undefined,
   apiUrl: string | null | undefined
 ): RequestInit => {
-  if (!authorization?.token || !apiUrl) return init;
+  if (!authorization?.enabled || !apiUrl) return init;
+
+  // Whitespace-only is as good as absent, and no valid token carries padding.
+  const token = authorization.token?.trim();
+  if (!token) return init;
 
   if (!isSecureApiUrl(apiUrl)) {
     if (!authorization.allowInsecure) return init;
-    warnInsecureOnce();
+    warnInsecureOnce(authorization);
   }
 
   const headers = new Headers(init.headers);
-  headers.set('Authorization', `Bearer ${authorization.token}`);
-  return { ...init, headers };
+  headers.set('Authorization', `Bearer ${token}`);
+  return { ...init, headers: Object.fromEntries(headers) };
 };

--- a/src/utils/authorization.ts
+++ b/src/utils/authorization.ts
@@ -51,16 +51,8 @@ const warnInsecureOnce = (authorization: AuthorizationOptions): void => {
  * unless a token exists, `enabled` opts in, and the token may be sent to
  * `apiUrl`.
  *
- * A header rather than a query-string param: request URLs are routinely
- * persisted in server-side logs, traces and error reports, so a bearer
- * credential must not travel in one. Applied to the measurement (`__down`,
- * `__up`), TURN credential and logging endpoints — the reachability, RPKI and
- * NXDOMAIN probe hosts are unrelated and never receive it.
- *
- * Resolved per target URL rather than once per engine, because a single config
- * may mix schemes: by default the token is withheld from anything that is not
- * known to be HTTPS, where an observer could lift it and the server treats it
- * as compromised.
+ * A header, not a query param: request URLs get persisted in logs and traces.
+ * Evaluated per target URL, since one config may mix schemes.
  */
 export const withAuthorizationHeader = (
   init: RequestInit,

--- a/src/utils/authorization.ts
+++ b/src/utils/authorization.ts
@@ -1,7 +1,18 @@
 /**
+ * The token and the single policy decision that governs it, passed as one unit
+ * so a transport change touches this module instead of every call site.
+ */
+export interface AuthorizationOptions {
+  /** See config `authorizationToken`. */
+  token: string | null;
+  /** See config `allowInsecureAuthorizationToken`. */
+  allowInsecure: boolean;
+}
+
+/**
  * Whether `apiUrl` resolves to an HTTPS endpoint. Relative URLs inherit the
  * page origin, so they can only be resolved inside a browser; anything we
- * cannot resolve is treated as insecure.
+ * cannot resolve is not known to be secure.
  */
 const isSecureApiUrl = (apiUrl: string): boolean => {
   try {
@@ -13,6 +24,20 @@ const isSecureApiUrl = (apiUrl: string): boolean => {
       return false;
     }
   }
+};
+
+/** Latched: a test issues hundreds of requests, and one warning is enough. */
+let warnedInsecure = false;
+
+const warnInsecureOnce = (): void => {
+  if (warnedInsecure) return;
+  warnedInsecure = true;
+  console.warn(
+    'Sending the authorization token to an endpoint that is not known to be ' +
+      'secure, because allowInsecureAuthorizationToken is enabled. Do not ' +
+      'enable this outside local development: the server treats a token seen ' +
+      'over plaintext as compromised and revokes it.'
+  );
 };
 
 /**
@@ -27,17 +52,23 @@ const isSecureApiUrl = (apiUrl: string): boolean => {
  * NXDOMAIN probe hosts are unrelated and never receive it.
  *
  * Resolved per target URL rather than once per engine, because a single config
- * may mix schemes: the token is never sent over plain HTTP, where an observer
- * could lift it and the server treats it as compromised.
+ * may mix schemes: by default the token is withheld from anything that is not
+ * known to be HTTPS, where an observer could lift it and the server treats it
+ * as compromised.
  */
 export const withAuthorizationHeader = (
   init: RequestInit,
-  token: string | null | undefined,
+  authorization: AuthorizationOptions | null | undefined,
   apiUrl: string | null | undefined
 ): RequestInit => {
-  if (!token || !apiUrl || !isSecureApiUrl(apiUrl)) return init;
+  if (!authorization?.token || !apiUrl) return init;
+
+  if (!isSecureApiUrl(apiUrl)) {
+    if (!authorization.allowInsecure) return init;
+    warnInsecureOnce();
+  }
 
   const headers = new Headers(init.headers);
-  headers.set('Authorization', `Bearer ${token}`);
+  headers.set('Authorization', `Bearer ${authorization.token}`);
   return { ...init, headers };
 };

--- a/tests/e2e/speedtest.test.ts
+++ b/tests/e2e/speedtest.test.ts
@@ -138,22 +138,23 @@ describe('SpeedTest E2E', () => {
 
       // Loaded latency (download): may be absent on very fast connections
       // where the parallel latency engine doesn't collect data before
-      // downloads finish. When present, should be reasonable.
-      if (summary.downLoadedLatency !== undefined) {
+      // downloads finish. Jitter is additionally `null` with fewer than 2
+      // samples, so these check for a number rather than for `undefined`.
+      if (typeof summary.downLoadedLatency === 'number') {
         expect(summary.downLoadedLatency).toBeGreaterThanOrEqual(0);
         expect(summary.downLoadedLatency).toBeLessThan(5000);
       }
-      if (summary.downLoadedJitter !== undefined) {
+      if (typeof summary.downLoadedJitter === 'number') {
         expect(summary.downLoadedJitter).toBeGreaterThanOrEqual(0);
         expect(summary.downLoadedJitter).toBeLessThan(2000);
       }
 
       // Loaded latency (upload): same caveat as download
-      if (summary.upLoadedLatency !== undefined) {
+      if (typeof summary.upLoadedLatency === 'number') {
         expect(summary.upLoadedLatency).toBeGreaterThanOrEqual(0);
         expect(summary.upLoadedLatency).toBeLessThan(5000);
       }
-      if (summary.upLoadedJitter !== undefined) {
+      if (typeof summary.upLoadedJitter === 'number') {
         expect(summary.upLoadedJitter).toBeGreaterThanOrEqual(0);
         expect(summary.upLoadedJitter).toBeLessThan(2000);
       }

--- a/tests/unit/config/authorizationToken.test.ts
+++ b/tests/unit/config/authorizationToken.test.ts
@@ -56,6 +56,28 @@ describe('authorizationToken', () => {
     expect(defaultConfig.authorizationToken).toBeNull();
   });
 
+  describe('authorizationEnabled', () => {
+    it('defaults to undefined, so a token alone is never sent', () => {
+      expect(resolveConfig({}).authorizationEnabled).toBeUndefined();
+      expect(defaultConfig.authorizationEnabled).toBeUndefined();
+      expect(
+        resolveConfig({ authorizationToken: TOKEN }).authorizationEnabled
+      ).toBeUndefined();
+    });
+
+    it.each(['header', true, false] as const)(
+      'survives the config merge as %o',
+      value => {
+        expect(
+          resolveConfig({
+            authorizationToken: TOKEN,
+            authorizationEnabled: value
+          }).authorizationEnabled
+        ).toBe(value);
+      }
+    );
+  });
+
   describe('allowInsecureAuthorizationToken', () => {
     it('defaults to false, so the token is HTTPS-only unless asked otherwise', () => {
       expect(resolveConfig({}).allowInsecureAuthorizationToken).toBe(false);

--- a/tests/unit/config/authorizationToken.test.ts
+++ b/tests/unit/config/authorizationToken.test.ts
@@ -1,68 +1,67 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import SpeedTestEngine from '../../../src/index.ts';
 import defaultConfig from '../../../src/config/defaultConfig.ts';
-import {
-  applyAuthorizationToken,
-  AUTHORIZABLE_URLS
-} from '../../../src/utils/authorization.ts';
 
 const TOKEN = 'test-token-123';
 
-/** Merges user config over the defaults the way the engine constructors do. */
-const resolveConfig = (userConfig: Partial<typeof defaultConfig>) =>
-  applyAuthorizationToken(Object.assign({}, defaultConfig, userConfig));
+/** `config` is protected, so a subclass is the supported way to inspect it. */
+class InspectableEngine extends SpeedTestEngine {
+  get resolvedConfig() {
+    return this.config;
+  }
+}
 
-describe('applyAuthorizationToken', () => {
-  beforeEach(() => {
-    vi.stubGlobal('window', {
-      location: { origin: 'https://speed.cloudflare.com' }
-    });
-  });
+const API_URL_KEYS = [
+  'downloadApiUrl',
+  'uploadApiUrl',
+  'turnServerCredsApiUrl',
+  'logAimApiUrl',
+  'logMeasurementApiUrl'
+] as const;
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+const resolveConfig = (userConfig: Parameters<typeof SpeedTestEngine>[0]) =>
+  new InspectableEngine({ autoStart: false, ...userConfig }).resolvedConfig;
 
-  it('attaches the token to every URL in AUTHORIZABLE_URLS', () => {
+describe('authorizationToken', () => {
+  it('never appears in any configured API URL', () => {
     const config = resolveConfig({
       authorizationToken: TOKEN,
       // Null by default, so set it to cover every key in the list.
       logMeasurementApiUrl: 'https://speed.cloudflare.com/__log'
     });
 
-    for (const key of AUTHORIZABLE_URLS) {
-      expect(new URL(config[key]!).searchParams.get('jwt'), key).toBe(TOKEN);
+    for (const key of API_URL_KEYS) {
+      expect(config[key] ?? '', key).not.toContain(TOKEN);
     }
   });
 
-  it('leaves disabled logging endpoints null', () => {
-    const config = resolveConfig({
-      authorizationToken: TOKEN,
-      logAimApiUrl: null,
-      logMeasurementApiUrl: null
-    });
+  it('leaves the configured API URLs exactly as given', () => {
+    const config = resolveConfig({ authorizationToken: TOKEN });
 
-    expect(config.logAimApiUrl).toBeNull();
-    expect(config.logMeasurementApiUrl).toBeNull();
+    for (const key of API_URL_KEYS) {
+      expect(config[key], key).toBe(defaultConfig[key]);
+    }
   });
 
-  it('does not attach the token to excluded hosts', () => {
+  it('is preserved on the config so the engines can attach it', () => {
+    expect(resolveConfig({ authorizationToken: TOKEN }).authorizationToken).toBe(
+      TOKEN
+    );
+  });
+
+  it('defaults to null', () => {
+    expect(resolveConfig({}).authorizationToken).toBeNull();
+    expect(defaultConfig.authorizationToken).toBeNull();
+  });
+
+  it('leaves the non-HTTP endpoints untouched', () => {
     const config = resolveConfig({ authorizationToken: TOKEN });
 
     expect(config.rpkiInvalidHost).toBe('invalid.rpki.cloudflare.com');
     expect(config.turnServerUri).toBe('turn.speed.cloudflare.com:50000');
   });
 
-  it('leaves every URL untouched when no token is configured', () => {
-    const config = resolveConfig({});
-
-    for (const key of AUTHORIZABLE_URLS) {
-      expect(config[key], key).toBe(defaultConfig[key]);
-    }
-  });
-
   it('does not mutate the shared defaultConfig object', () => {
-    // applyAuthorizationToken mutates in place, so it must only ever be handed
-    // a freshly merged object — otherwise the token leaks across instances.
     resolveConfig({ authorizationToken: TOKEN });
 
     expect(defaultConfig.downloadApiUrl).toBe(
@@ -72,18 +71,5 @@ describe('applyAuthorizationToken', () => {
       'https://speed.cloudflare.com/__results'
     );
     expect(defaultConfig.authorizationToken).toBeNull();
-  });
-
-  it('does not attach the token over plain HTTP', () => {
-    const config = resolveConfig({
-      authorizationToken: TOKEN,
-      downloadApiUrl: 'http://speed.cloudflare.com/__down',
-      uploadApiUrl: 'http://speed.cloudflare.com/__up'
-    });
-
-    expect(config.downloadApiUrl).toBe('http://speed.cloudflare.com/__down');
-    expect(config.uploadApiUrl).toBe('http://speed.cloudflare.com/__up');
-    // HTTPS endpoints in the same config are still attributed.
-    expect(new URL(config.logAimApiUrl!).searchParams.get('jwt')).toBe(TOKEN);
   });
 });

--- a/tests/unit/config/authorizationToken.test.ts
+++ b/tests/unit/config/authorizationToken.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import SpeedTestEngine from '../../../src/index.ts';
-import defaultConfig from '../../../src/config/defaultConfig.ts';
+import defaultConfig, {
+  type ConfigOptions
+} from '../../../src/config/defaultConfig.ts';
 
 const TOKEN = 'test-token-123';
 
@@ -19,7 +21,7 @@ const API_URL_KEYS = [
   'logMeasurementApiUrl'
 ] as const;
 
-const resolveConfig = (userConfig: Parameters<typeof SpeedTestEngine>[0]) =>
+const resolveConfig = (userConfig: ConfigOptions = {}) =>
   new InspectableEngine({ autoStart: false, ...userConfig }).resolvedConfig;
 
 describe('authorizationToken', () => {
@@ -52,6 +54,34 @@ describe('authorizationToken', () => {
   it('defaults to null', () => {
     expect(resolveConfig({}).authorizationToken).toBeNull();
     expect(defaultConfig.authorizationToken).toBeNull();
+  });
+
+  describe('allowInsecureAuthorizationToken', () => {
+    it('defaults to false, so the token is HTTPS-only unless asked otherwise', () => {
+      expect(resolveConfig({}).allowInsecureAuthorizationToken).toBe(false);
+      expect(defaultConfig.allowInsecureAuthorizationToken).toBe(false);
+    });
+
+    it('survives the config merge when opted into', () => {
+      expect(
+        resolveConfig({
+          authorizationToken: TOKEN,
+          allowInsecureAuthorizationToken: true
+        }).allowInsecureAuthorizationToken
+      ).toBe(true);
+    });
+
+    it('still keeps the token out of every URL', () => {
+      const config = resolveConfig({
+        authorizationToken: TOKEN,
+        allowInsecureAuthorizationToken: true,
+        logMeasurementApiUrl: 'http://localhost:8787/__log'
+      });
+
+      for (const key of API_URL_KEYS) {
+        expect(config[key] ?? '', key).not.toContain(TOKEN);
+      }
+    });
   });
 
   it('leaves the non-HTTP endpoints untouched', () => {

--- a/tests/unit/engines/loadNetworkAuthorization.test.ts
+++ b/tests/unit/engines/loadNetworkAuthorization.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import LoadNetworkEngine from '../../../src/engines/LoadNetworkEngine';
+import type { AuthorizationOptions } from '../../../src/utils/authorization';
+
+/**
+ * The load generator saturates the same `__down`/`__up` endpoints as a real
+ * measurement, so it has to carry the token too. It is covered here because
+ * the e2e suite skips packet loss (CORS), which is the only path that builds
+ * one — an unwrapped fetch here would otherwise go unnoticed.
+ */
+
+const TOKEN = 'eyJhbGciOiJFUzI1NiJ9.payload.signature';
+
+const auth = (
+  overrides: Partial<AuthorizationOptions> = {}
+): AuthorizationOptions => ({
+  token: TOKEN,
+  enabled: 'header',
+  allowInsecure: false,
+  ...overrides
+});
+
+/** Every URL the engine fetched, paired with its Authorization header. */
+const fetchedWithAuth = (): [string, string | null][] =>
+  vi
+    .mocked(globalThis.fetch)
+    .mock.calls.map(([url, init]) => [
+      String(url),
+      new Headers(init?.headers).get('authorization')
+    ]);
+
+describe('LoadNetworkEngine authorization', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      location: { origin: 'https://speed.example.com' }
+    });
+    // Never resolves: one iteration per engine is enough, and the loop cannot
+    // schedule another while the previous fetch is pending.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends the token on download load requests', () => {
+    const engine = new LoadNetworkEngine({
+      download: { apiUrl: 'https://speed.example.com/__down', chunkSize: 1e5 },
+      authorization: auth()
+    });
+    engine.stop();
+
+    expect(fetchedWithAuth()).toEqual([
+      [
+        'https://speed.example.com/__down?bytes=100000',
+        `Bearer ${TOKEN}`
+      ]
+    ]);
+  });
+
+  it('sends the token on upload load requests', () => {
+    const engine = new LoadNetworkEngine({
+      upload: { apiUrl: 'https://speed.example.com/__up', chunkSize: 10 },
+      authorization: auth()
+    });
+    engine.stop();
+
+    expect(fetchedWithAuth()).toEqual([
+      ['https://speed.example.com/__up', `Bearer ${TOKEN}`]
+    ]);
+  });
+
+  it('sends the token on both loops at once', () => {
+    const engine = new LoadNetworkEngine({
+      download: { apiUrl: 'https://speed.example.com/__down', chunkSize: 1e5 },
+      upload: { apiUrl: 'https://speed.example.com/__up', chunkSize: 10 },
+      authorization: auth()
+    });
+    engine.stop();
+
+    expect(fetchedWithAuth().map(([, header]) => header)).toEqual([
+      `Bearer ${TOKEN}`,
+      `Bearer ${TOKEN}`
+    ]);
+  });
+
+  it('keeps the upload method and body while adding the header', () => {
+    const engine = new LoadNetworkEngine({
+      upload: { apiUrl: 'https://speed.example.com/__up', chunkSize: 4 },
+      authorization: auth()
+    });
+    engine.stop();
+
+    const init = vi.mocked(globalThis.fetch).mock.calls[0][1];
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBe('0000');
+  });
+
+  it('sends nothing when authorization was not opted in', () => {
+    const engine = new LoadNetworkEngine({
+      download: { apiUrl: 'https://speed.example.com/__down', chunkSize: 1e5 },
+      authorization: auth({ enabled: undefined })
+    });
+    engine.stop();
+
+    expect(fetchedWithAuth()[0][1]).toBeNull();
+  });
+
+  it('sends nothing when no authorization is supplied at all', () => {
+    const engine = new LoadNetworkEngine({
+      download: { apiUrl: 'https://speed.example.com/__down', chunkSize: 1e5 }
+    });
+    engine.stop();
+
+    expect(fetchedWithAuth()[0][1]).toBeNull();
+  });
+
+  it('withholds the token from a plain-HTTP endpoint', () => {
+    const engine = new LoadNetworkEngine({
+      download: { apiUrl: 'http://speed.example.com/__down', chunkSize: 1e5 },
+      authorization: auth()
+    });
+    engine.stop();
+
+    expect(fetchedWithAuth()[0][1]).toBeNull();
+  });
+});

--- a/tests/unit/logging/logFinalResults.test.ts
+++ b/tests/unit/logging/logFinalResults.test.ts
@@ -17,7 +17,8 @@ const makeResults = (): Results =>
 
 const config = {
   apiUrl: 'https://aim.example.com/__results',
-  sessionId: undefined
+  sessionId: undefined,
+  authorization: null
 };
 
 describe('logAimResults', () => {

--- a/tests/unit/utils/authorization.test.ts
+++ b/tests/unit/utils/authorization.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { withAuthorizationHeader } from '../../../src/utils/authorization.ts';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+  withAuthorizationHeader,
+  type AuthorizationOptions
+} from '../../../src/utils/authorization.ts';
 
 /** The helper resolves relative URLs against the page origin, like the engines do. */
 const stubOrigin = (origin: string): void => {
@@ -8,19 +11,30 @@ const stubOrigin = (origin: string): void => {
 
 const TOKEN = 'eyJhbGciOiJFUzI1NiJ9.payload.signature';
 
+const secure: AuthorizationOptions = { token: TOKEN, allowInsecure: false };
+const insecureAllowed: AuthorizationOptions = {
+  token: TOKEN,
+  allowInsecure: true
+};
+
 /** Header lookup that works whichever HeadersInit shape came back. */
 const authOf = (init: RequestInit): string | null =>
   new Headers(init.headers).get('authorization');
 
 describe('withAuthorizationHeader', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('attaches the token as a bearer Authorization header', () => {
     const init = withAuthorizationHeader(
       {},
-      TOKEN,
+      secure,
       'https://speed.example.com/__down'
     );
 
@@ -30,7 +44,7 @@ describe('withAuthorizationHeader', () => {
   it('never puts the token in the URL', () => {
     // The whole point of the header: no caller may end up logging the token.
     const apiUrl = 'https://speed.example.com/__down?bytes=100000';
-    const init = withAuthorizationHeader({}, TOKEN, apiUrl);
+    const init = withAuthorizationHeader({}, secure, apiUrl);
 
     expect(JSON.stringify(init)).not.toContain(TOKEN.split('.')[1]);
     expect(apiUrl).not.toContain(TOKEN);
@@ -40,7 +54,7 @@ describe('withAuthorizationHeader', () => {
     const body = 'payload';
     const init = withAuthorizationHeader(
       { method: 'POST', body, credentials: 'include' },
-      TOKEN,
+      secure,
       'https://speed.example.com/__up'
     );
 
@@ -52,7 +66,7 @@ describe('withAuthorizationHeader', () => {
   it('preserves headers the caller already set', () => {
     const init = withAuthorizationHeader(
       { headers: { 'content-type': 'text/plain' } },
-      TOKEN,
+      secure,
       'https://speed.example.com/__log'
     );
 
@@ -63,42 +77,35 @@ describe('withAuthorizationHeader', () => {
 
   it('does not mutate the init it was given', () => {
     const original: RequestInit = { method: 'POST' };
-    withAuthorizationHeader(original, TOKEN, 'https://speed.example.com/__up');
+    withAuthorizationHeader(original, secure, 'https://speed.example.com/__up');
 
     expect(original.headers).toBeUndefined();
   });
 
   it('returns the init untouched when there is no token', () => {
     const original: RequestInit = { method: 'POST' };
+    const url = 'https://speed.example.com/__up';
 
     expect(
-      withAuthorizationHeader(original, null, 'https://speed.example.com/__up')
+      withAuthorizationHeader(
+        original,
+        { token: null, allowInsecure: false },
+        url
+      )
     ).toBe(original);
     expect(
-      withAuthorizationHeader(original, '', 'https://speed.example.com/__up')
+      withAuthorizationHeader(original, { token: '', allowInsecure: true }, url)
     ).toBe(original);
+    expect(withAuthorizationHeader(original, null, url)).toBe(original);
+    expect(withAuthorizationHeader(original, undefined, url)).toBe(original);
   });
 
   it('resolves relative URLs against the page origin', () => {
     stubOrigin('https://speed.example.com');
 
-    expect(authOf(withAuthorizationHeader({}, TOKEN, '/__down'))).toBe(
+    expect(authOf(withAuthorizationHeader({}, secure, '/__down'))).toBe(
       `Bearer ${TOKEN}`
     );
-  });
-
-  it('never attaches the token over plain HTTP', () => {
-    expect(
-      authOf(
-        withAuthorizationHeader({}, TOKEN, 'http://speed.example.com/__down')
-      )
-    ).toBeNull();
-  });
-
-  it('never attaches the token to a relative URL on an HTTP page', () => {
-    stubOrigin('http://speed.example.com');
-
-    expect(authOf(withAuthorizationHeader({}, TOKEN, '/__down'))).toBeNull();
   });
 
   it('attaches to absolute URLs without a DOM', () => {
@@ -108,23 +115,113 @@ describe('withAuthorizationHeader', () => {
 
     expect(
       authOf(
-        withAuthorizationHeader({}, TOKEN, 'https://speed.example.com/__down')
+        withAuthorizationHeader({}, secure, 'https://speed.example.com/__down')
       )
     ).toBe(`Bearer ${TOKEN}`);
-  });
-
-  it('does not throw on a URL it cannot resolve', () => {
-    expect(typeof window).toBe('undefined');
-
-    expect(() => withAuthorizationHeader({}, TOKEN, '/__down')).not.toThrow();
-    expect(authOf(withAuthorizationHeader({}, TOKEN, '/__down'))).toBeNull();
-    expect(authOf(withAuthorizationHeader({}, TOKEN, 'not a url'))).toBeNull();
   });
 
   it('returns the init untouched when there is no target URL', () => {
     const original: RequestInit = {};
 
-    expect(withAuthorizationHeader(original, TOKEN, null)).toBe(original);
-    expect(withAuthorizationHeader(original, TOKEN, undefined)).toBe(original);
+    expect(withAuthorizationHeader(original, secure, null)).toBe(original);
+    expect(withAuthorizationHeader(original, secure, undefined)).toBe(original);
+  });
+
+  describe('by default', () => {
+    it('never attaches the token over plain HTTP', () => {
+      expect(
+        authOf(
+          withAuthorizationHeader({}, secure, 'http://speed.example.com/__down')
+        )
+      ).toBeNull();
+    });
+
+    it('never attaches the token to a relative URL on an HTTP page', () => {
+      stubOrigin('http://speed.example.com');
+
+      expect(authOf(withAuthorizationHeader({}, secure, '/__down'))).toBeNull();
+    });
+
+    it('does not throw on a URL it cannot resolve, and withholds the token', () => {
+      expect(typeof window).toBe('undefined');
+
+      expect(() => withAuthorizationHeader({}, secure, '/__down')).not.toThrow();
+      expect(authOf(withAuthorizationHeader({}, secure, '/__down'))).toBeNull();
+      expect(authOf(withAuthorizationHeader({}, secure, 'not a url'))).toBeNull();
+    });
+  });
+
+  describe('with allowInsecure', () => {
+    it('attaches the token over plain HTTP', () => {
+      expect(
+        authOf(
+          withAuthorizationHeader(
+            {},
+            insecureAllowed,
+            'http://localhost:8787/__down'
+          )
+        )
+      ).toBe(`Bearer ${TOKEN}`);
+    });
+
+    it('attaches the token to a relative URL on an HTTP page', () => {
+      stubOrigin('http://localhost:3000');
+
+      expect(authOf(withAuthorizationHeader({}, insecureAllowed, '/__down'))).toBe(
+        `Bearer ${TOKEN}`
+      );
+    });
+
+    it('attaches the token to a URL it cannot resolve', () => {
+      // The flag means "stop policing transport", so an unresolvable target is
+      // no longer a reason to withhold.
+      expect(typeof window).toBe('undefined');
+
+      expect(authOf(withAuthorizationHeader({}, insecureAllowed, '/__down'))).toBe(
+        `Bearer ${TOKEN}`
+      );
+    });
+
+    it('still leaves a secure request untouched by the escape hatch', () => {
+      expect(
+        authOf(
+          withAuthorizationHeader(
+            {},
+            insecureAllowed,
+            'https://speed.example.com/__down'
+          )
+        )
+      ).toBe(`Bearer ${TOKEN}`);
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('warns once, not once per request', async () => {
+      // The latch is module state, so this needs a fresh module instance.
+      vi.resetModules();
+      const { withAuthorizationHeader: fresh } = await import(
+        '../../../src/utils/authorization.ts'
+      );
+      const url = 'http://localhost:8787/__down';
+
+      fresh({}, insecureAllowed, url);
+      fresh({}, insecureAllowed, url);
+      fresh({}, insecureAllowed, 'http://localhost:8787/__up');
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(console.warn).mock.calls[0][0]).toContain(
+        'allowInsecureAuthorizationToken'
+      );
+    });
+
+    it('does not warn when there is no token to send', async () => {
+      vi.resetModules();
+      const { withAuthorizationHeader: fresh } = await import(
+        '../../../src/utils/authorization.ts'
+      );
+
+      fresh({}, { token: null, allowInsecure: true }, 'http://localhost/__down');
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/utils/authorization.test.ts
+++ b/tests/unit/utils/authorization.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import {
-  AUTHORIZATION_TOKEN_PARAM,
-  redactAuthorizationToken,
-  withAuthorizationToken
-} from '../../../src/utils/authorization.ts';
+import { withAuthorizationHeader } from '../../../src/utils/authorization.ts';
 
 /** The helper resolves relative URLs against the page origin, like the engines do. */
 const stubOrigin = (origin: string): void => {
@@ -12,141 +8,123 @@ const stubOrigin = (origin: string): void => {
 
 const TOKEN = 'eyJhbGciOiJFUzI1NiJ9.payload.signature';
 
-describe('withAuthorizationToken', () => {
+/** Header lookup that works whichever HeadersInit shape came back. */
+const authOf = (init: RequestInit): string | null =>
+  new Headers(init.headers).get('authorization');
+
+describe('withAuthorizationHeader', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('appends the token as a query-string param', () => {
-    stubOrigin('https://speed.example.com');
-
-    const url = withAuthorizationToken(
-      'https://speed.example.com/__down',
-      TOKEN
+  it('attaches the token as a bearer Authorization header', () => {
+    const init = withAuthorizationHeader(
+      {},
+      TOKEN,
+      'https://speed.example.com/__down'
     );
 
-    expect(new URL(url).searchParams.get(AUTHORIZATION_TOKEN_PARAM)).toBe(
-      TOKEN
-    );
+    expect(authOf(init)).toBe(`Bearer ${TOKEN}`);
   });
 
-  it('uses `jwt` as the param name', () => {
-    stubOrigin('https://speed.example.com');
+  it('never puts the token in the URL', () => {
+    // The whole point of the header: no caller may end up logging the token.
+    const apiUrl = 'https://speed.example.com/__down?bytes=100000';
+    const init = withAuthorizationHeader({}, TOKEN, apiUrl);
+
+    expect(JSON.stringify(init)).not.toContain(TOKEN.split('.')[1]);
+    expect(apiUrl).not.toContain(TOKEN);
+  });
+
+  it('preserves the rest of the request init', () => {
+    const body = 'payload';
+    const init = withAuthorizationHeader(
+      { method: 'POST', body, credentials: 'include' },
+      TOKEN,
+      'https://speed.example.com/__up'
+    );
+
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(body);
+    expect(init.credentials).toBe('include');
+  });
+
+  it('preserves headers the caller already set', () => {
+    const init = withAuthorizationHeader(
+      { headers: { 'content-type': 'text/plain' } },
+      TOKEN,
+      'https://speed.example.com/__log'
+    );
+
+    const headers = new Headers(init.headers);
+    expect(headers.get('content-type')).toBe('text/plain');
+    expect(headers.get('authorization')).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('does not mutate the init it was given', () => {
+    const original: RequestInit = { method: 'POST' };
+    withAuthorizationHeader(original, TOKEN, 'https://speed.example.com/__up');
+
+    expect(original.headers).toBeUndefined();
+  });
+
+  it('returns the init untouched when there is no token', () => {
+    const original: RequestInit = { method: 'POST' };
 
     expect(
-      withAuthorizationToken('https://speed.example.com/__up', 'abc')
-    ).toBe('https://speed.example.com/__up?jwt=abc');
-  });
-
-  it('preserves query params already present on the URL', () => {
-    stubOrigin('https://speed.example.com');
-
-    const url = new URL(
-      withAuthorizationToken(
-        'https://speed.example.com/__down?foo=bar&baz=1',
-        TOKEN
-      )
-    );
-
-    expect(url.searchParams.get('foo')).toBe('bar');
-    expect(url.searchParams.get('baz')).toBe('1');
-    expect(url.searchParams.get(AUTHORIZATION_TOKEN_PARAM)).toBe(TOKEN);
-  });
-
-  it('url-encodes tokens containing reserved characters', () => {
-    stubOrigin('https://speed.example.com');
-
-    const url = withAuthorizationToken(
-      'https://speed.example.com/__down',
-      'a+b/c=d&e'
-    );
-
-    expect(url).not.toContain('a+b/c=d&e');
-    expect(new URL(url).searchParams.get(AUTHORIZATION_TOKEN_PARAM)).toBe(
-      'a+b/c=d&e'
-    );
+      withAuthorizationHeader(original, null, 'https://speed.example.com/__up')
+    ).toBe(original);
+    expect(
+      withAuthorizationHeader(original, '', 'https://speed.example.com/__up')
+    ).toBe(original);
   });
 
   it('resolves relative URLs against the page origin', () => {
     stubOrigin('https://speed.example.com');
 
-    expect(withAuthorizationToken('/__down', TOKEN)).toBe(
-      `https://speed.example.com/__down?jwt=${encodeURIComponent(TOKEN)}`
-    );
-  });
-
-  it('returns the URL untouched when there is no token', () => {
-    stubOrigin('https://speed.example.com');
-
-    expect(
-      withAuthorizationToken('https://speed.example.com/__down', null)
-    ).toBe('https://speed.example.com/__down');
-    expect(withAuthorizationToken('https://speed.example.com/__down', '')).toBe(
-      'https://speed.example.com/__down'
+    expect(authOf(withAuthorizationHeader({}, TOKEN, '/__down'))).toBe(
+      `Bearer ${TOKEN}`
     );
   });
 
   it('never attaches the token over plain HTTP', () => {
-    stubOrigin('https://speed.example.com');
-
     expect(
-      withAuthorizationToken('http://speed.example.com/__down', TOKEN)
-    ).toBe('http://speed.example.com/__down');
+      authOf(
+        withAuthorizationHeader({}, TOKEN, 'http://speed.example.com/__down')
+      )
+    ).toBeNull();
   });
 
   it('never attaches the token to a relative URL on an HTTP page', () => {
     stubOrigin('http://speed.example.com');
 
-    expect(withAuthorizationToken('/__down', TOKEN)).toBe('/__down');
+    expect(authOf(withAuthorizationHeader({}, TOKEN, '/__down'))).toBeNull();
   });
 
-  it('tokenizes absolute URLs without a DOM', () => {
+  it('attaches to absolute URLs without a DOM', () => {
     // Every default API URL is absolute, so constructing an engine with a token
     // must not require a DOM.
     expect(typeof window).toBe('undefined');
+
     expect(
-      withAuthorizationToken('https://speed.example.com/__down', 'abc')
-    ).toBe('https://speed.example.com/__down?jwt=abc');
-    expect(() => withAuthorizationToken('/__down', null)).not.toThrow();
-  });
-});
-
-describe('redactAuthorizationToken', () => {
-  const tokenized = withAuthorizationToken(
-    'https://speed.example.com/__down?bytes=100000',
-    TOKEN
-  );
-
-  it('masks the token', () => {
-    const redacted = redactAuthorizationToken(tokenized);
-
-    expect(redacted).not.toContain(TOKEN);
-    expect(new URL(redacted).searchParams.get(AUTHORIZATION_TOKEN_PARAM)).toBe(
-      'REDACTED'
-    );
+      authOf(
+        withAuthorizationHeader({}, TOKEN, 'https://speed.example.com/__down')
+      )
+    ).toBe(`Bearer ${TOKEN}`);
   });
 
-  it('leaves the rest of the URL intact', () => {
-    const redacted = new URL(redactAuthorizationToken(tokenized));
-
-    expect(redacted.origin + redacted.pathname).toBe(
-      'https://speed.example.com/__down'
-    );
-    expect(redacted.searchParams.get('bytes')).toBe('100000');
-  });
-
-  it('returns the URL untouched when it carries no token', () => {
-    const url = 'https://speed.example.com/__down?bytes=100000';
-
-    expect(redactAuthorizationToken(url)).toBe(url);
-  });
-
-  it('never throws on a URL it cannot parse', () => {
-    // Runs on the error path, so it must not mask the original failure.
+  it('does not throw on a URL it cannot resolve', () => {
     expect(typeof window).toBe('undefined');
-    expect(redactAuthorizationToken('/__down?jwt=abc')).toBe(
-      '/__down?jwt=abc'
-    );
-    expect(redactAuthorizationToken('not a url')).toBe('not a url');
+
+    expect(() => withAuthorizationHeader({}, TOKEN, '/__down')).not.toThrow();
+    expect(authOf(withAuthorizationHeader({}, TOKEN, '/__down'))).toBeNull();
+    expect(authOf(withAuthorizationHeader({}, TOKEN, 'not a url'))).toBeNull();
+  });
+
+  it('returns the init untouched when there is no target URL', () => {
+    const original: RequestInit = {};
+
+    expect(withAuthorizationHeader(original, TOKEN, null)).toBe(original);
+    expect(withAuthorizationHeader(original, TOKEN, undefined)).toBe(original);
   });
 });

--- a/tests/unit/utils/authorization.test.ts
+++ b/tests/unit/utils/authorization.test.ts
@@ -11,11 +11,15 @@ const stubOrigin = (origin: string): void => {
 
 const TOKEN = 'eyJhbGciOiJFUzI1NiJ9.payload.signature';
 
-const secure: AuthorizationOptions = { token: TOKEN, allowInsecure: false };
-const insecureAllowed: AuthorizationOptions = {
+/** A fresh object per call: the insecure warning is latched per options object. */
+const auth = (
+  overrides: Partial<AuthorizationOptions> = {}
+): AuthorizationOptions => ({
   token: TOKEN,
-  allowInsecure: true
-};
+  enabled: 'header',
+  allowInsecure: false,
+  ...overrides
+});
 
 /** Header lookup that works whichever HeadersInit shape came back. */
 const authOf = (init: RequestInit): string | null =>
@@ -34,7 +38,7 @@ describe('withAuthorizationHeader', () => {
   it('attaches the token as a bearer Authorization header', () => {
     const init = withAuthorizationHeader(
       {},
-      secure,
+      auth(),
       'https://speed.example.com/__down'
     );
 
@@ -44,17 +48,20 @@ describe('withAuthorizationHeader', () => {
   it('never puts the token in the URL', () => {
     // The whole point of the header: no caller may end up logging the token.
     const apiUrl = 'https://speed.example.com/__down?bytes=100000';
-    const init = withAuthorizationHeader({}, secure, apiUrl);
+    const init = withAuthorizationHeader({}, auth(), apiUrl);
 
-    expect(JSON.stringify(init)).not.toContain(TOKEN.split('.')[1]);
+    // The helper takes the URL by value and cannot rewrite it, so the check
+    // that matters is that the token travels in the header instead.
     expect(apiUrl).not.toContain(TOKEN);
+    expect(authOf(init)).toBe(`Bearer ${TOKEN}`);
+    expect(init).not.toHaveProperty('url');
   });
 
   it('preserves the rest of the request init', () => {
     const body = 'payload';
     const init = withAuthorizationHeader(
       { method: 'POST', body, credentials: 'include' },
-      secure,
+      auth(),
       'https://speed.example.com/__up'
     );
 
@@ -66,7 +73,7 @@ describe('withAuthorizationHeader', () => {
   it('preserves headers the caller already set', () => {
     const init = withAuthorizationHeader(
       { headers: { 'content-type': 'text/plain' } },
-      secure,
+      auth(),
       'https://speed.example.com/__log'
     );
 
@@ -75,35 +82,38 @@ describe('withAuthorizationHeader', () => {
     expect(headers.get('authorization')).toBe(`Bearer ${TOKEN}`);
   });
 
+  it('returns headers as a plain object, not a Headers instance', () => {
+    const init = withAuthorizationHeader(
+      { headers: { 'content-type': 'text/plain' } },
+      auth(),
+      'https://speed.example.com/__log'
+    );
+
+    expect(init.headers).not.toBeInstanceOf(Headers);
+    expect(init.headers).toEqual({
+      'content-type': 'text/plain',
+      authorization: `Bearer ${TOKEN}`
+    });
+  });
+
   it('does not mutate the init it was given', () => {
     const original: RequestInit = { method: 'POST' };
-    withAuthorizationHeader(original, secure, 'https://speed.example.com/__up');
+    withAuthorizationHeader(original, auth(), 'https://speed.example.com/__up');
 
     expect(original.headers).toBeUndefined();
   });
 
-  it('returns the init untouched when there is no token', () => {
-    const original: RequestInit = { method: 'POST' };
-    const url = 'https://speed.example.com/__up';
+  it('returns the init untouched when there is no target URL', () => {
+    const original: RequestInit = {};
 
-    expect(
-      withAuthorizationHeader(
-        original,
-        { token: null, allowInsecure: false },
-        url
-      )
-    ).toBe(original);
-    expect(
-      withAuthorizationHeader(original, { token: '', allowInsecure: true }, url)
-    ).toBe(original);
-    expect(withAuthorizationHeader(original, null, url)).toBe(original);
-    expect(withAuthorizationHeader(original, undefined, url)).toBe(original);
+    expect(withAuthorizationHeader(original, auth(), null)).toBe(original);
+    expect(withAuthorizationHeader(original, auth(), undefined)).toBe(original);
   });
 
   it('resolves relative URLs against the page origin', () => {
     stubOrigin('https://speed.example.com');
 
-    expect(authOf(withAuthorizationHeader({}, secure, '/__down'))).toBe(
+    expect(authOf(withAuthorizationHeader({}, auth(), '/__down'))).toBe(
       `Bearer ${TOKEN}`
     );
   });
@@ -115,23 +125,85 @@ describe('withAuthorizationHeader', () => {
 
     expect(
       authOf(
-        withAuthorizationHeader({}, secure, 'https://speed.example.com/__down')
+        withAuthorizationHeader({}, auth(), 'https://speed.example.com/__down')
       )
     ).toBe(`Bearer ${TOKEN}`);
   });
 
-  it('returns the init untouched when there is no target URL', () => {
-    const original: RequestInit = {};
+  describe('enabled', () => {
+    const url = 'https://speed.example.com/__down';
 
-    expect(withAuthorizationHeader(original, secure, null)).toBe(original);
-    expect(withAuthorizationHeader(original, secure, undefined)).toBe(original);
+    it("sends the token for 'header'", () => {
+      expect(authOf(withAuthorizationHeader({}, auth(), url))).toBe(
+        `Bearer ${TOKEN}`
+      );
+    });
+
+    it('sends the token for true, which is an alias for header', () => {
+      expect(
+        authOf(withAuthorizationHeader({}, auth({ enabled: true }), url))
+      ).toBe(`Bearer ${TOKEN}`);
+    });
+
+    it('withholds a token that was never opted in', () => {
+      // A token alone must not be sent: opting in is explicit.
+      const original: RequestInit = { method: 'GET' };
+
+      expect(
+        withAuthorizationHeader(original, auth({ enabled: undefined }), url)
+      ).toBe(original);
+      expect(
+        withAuthorizationHeader(original, auth({ enabled: false }), url)
+      ).toBe(original);
+    });
+
+    it('returns the init untouched when there is no authorization at all', () => {
+      const original: RequestInit = { method: 'GET' };
+
+      expect(withAuthorizationHeader(original, null, url)).toBe(original);
+      expect(withAuthorizationHeader(original, undefined, url)).toBe(original);
+    });
+  });
+
+  describe('token values', () => {
+    const url = 'https://speed.example.com/__down';
+
+    it('returns the init untouched when there is no token', () => {
+      const original: RequestInit = { method: 'POST' };
+
+      expect(
+        withAuthorizationHeader(original, auth({ token: null }), url)
+      ).toBe(original);
+      expect(withAuthorizationHeader(original, auth({ token: '' }), url)).toBe(
+        original
+      );
+    });
+
+    it('treats a whitespace-only token as absent', () => {
+      const original: RequestInit = { method: 'POST' };
+
+      expect(withAuthorizationHeader(original, auth({ token: ' ' }), url)).toBe(
+        original
+      );
+      expect(
+        withAuthorizationHeader(original, auth({ token: '\t\n ' }), url)
+      ).toBe(original);
+    });
+
+    it('trims a padded token rather than sending the padding', () => {
+      expect(
+        authOf(
+          withAuthorizationHeader({}, auth({ token: `  ${TOKEN}\n` }), url)
+        )
+      ).toBe(`Bearer ${TOKEN}`);
+    });
   });
 
   describe('by default', () => {
     it('never attaches the token over plain HTTP', () => {
       expect(
         authOf(
-          withAuthorizationHeader({}, secure, 'http://speed.example.com/__down')
+          withAuthorizationHeader({}, auth(), 'http://speed.example.com/__down')
         )
       ).toBeNull();
     });
@@ -139,25 +211,31 @@ describe('withAuthorizationHeader', () => {
     it('never attaches the token to a relative URL on an HTTP page', () => {
       stubOrigin('http://speed.example.com');
 
-      expect(authOf(withAuthorizationHeader({}, secure, '/__down'))).toBeNull();
+      expect(authOf(withAuthorizationHeader({}, auth(), '/__down'))).toBeNull();
     });
 
     it('does not throw on a URL it cannot resolve, and withholds the token', () => {
       expect(typeof window).toBe('undefined');
 
-      expect(() => withAuthorizationHeader({}, secure, '/__down')).not.toThrow();
-      expect(authOf(withAuthorizationHeader({}, secure, '/__down'))).toBeNull();
-      expect(authOf(withAuthorizationHeader({}, secure, 'not a url'))).toBeNull();
+      expect(() =>
+        withAuthorizationHeader({}, auth(), '/__down')
+      ).not.toThrow();
+      expect(authOf(withAuthorizationHeader({}, auth(), '/__down'))).toBeNull();
+      expect(
+        authOf(withAuthorizationHeader({}, auth(), 'not a url'))
+      ).toBeNull();
     });
   });
 
   describe('with allowInsecure', () => {
+    const insecure = (): AuthorizationOptions => auth({ allowInsecure: true });
+
     it('attaches the token over plain HTTP', () => {
       expect(
         authOf(
           withAuthorizationHeader(
             {},
-            insecureAllowed,
+            insecure(),
             'http://localhost:8787/__down'
           )
         )
@@ -167,7 +245,7 @@ describe('withAuthorizationHeader', () => {
     it('attaches the token to a relative URL on an HTTP page', () => {
       stubOrigin('http://localhost:3000');
 
-      expect(authOf(withAuthorizationHeader({}, insecureAllowed, '/__down'))).toBe(
+      expect(authOf(withAuthorizationHeader({}, insecure(), '/__down'))).toBe(
         `Bearer ${TOKEN}`
       );
     });
@@ -177,35 +255,28 @@ describe('withAuthorizationHeader', () => {
       // no longer a reason to withhold.
       expect(typeof window).toBe('undefined');
 
-      expect(authOf(withAuthorizationHeader({}, insecureAllowed, '/__down'))).toBe(
+      expect(authOf(withAuthorizationHeader({}, insecure(), '/__down'))).toBe(
         `Bearer ${TOKEN}`
       );
     });
 
-    it('still leaves a secure request untouched by the escape hatch', () => {
-      expect(
-        authOf(
-          withAuthorizationHeader(
-            {},
-            insecureAllowed,
-            'https://speed.example.com/__down'
-          )
-        )
-      ).toBe(`Bearer ${TOKEN}`);
+    it('does not warn when the target is secure', () => {
+      withAuthorizationHeader(
+        {},
+        insecure(),
+        'https://speed.example.com/__down'
+      );
+
       expect(console.warn).not.toHaveBeenCalled();
     });
 
-    it('warns once, not once per request', async () => {
-      // The latch is module state, so this needs a fresh module instance.
-      vi.resetModules();
-      const { withAuthorizationHeader: fresh } = await import(
-        '../../../src/utils/authorization.ts'
-      );
-      const url = 'http://localhost:8787/__down';
+    it('warns once per engine, not once per request', () => {
+      // One options object is built per engine, so the latch is per run.
+      const shared = insecure();
 
-      fresh({}, insecureAllowed, url);
-      fresh({}, insecureAllowed, url);
-      fresh({}, insecureAllowed, 'http://localhost:8787/__up');
+      withAuthorizationHeader({}, shared, 'http://localhost:8787/__down');
+      withAuthorizationHeader({}, shared, 'http://localhost:8787/__down');
+      withAuthorizationHeader({}, shared, 'http://localhost:8787/__up');
 
       expect(console.warn).toHaveBeenCalledTimes(1);
       expect(vi.mocked(console.warn).mock.calls[0][0]).toContain(
@@ -213,13 +284,31 @@ describe('withAuthorizationHeader', () => {
       );
     });
 
-    it('does not warn when there is no token to send', async () => {
-      vi.resetModules();
-      const { withAuthorizationHeader: fresh } = await import(
-        '../../../src/utils/authorization.ts'
+    it('warns again for a new engine, so a second run is not silent', () => {
+      const url = 'http://localhost:8787/__down';
+
+      withAuthorizationHeader({}, insecure(), url);
+      withAuthorizationHeader({}, insecure(), url);
+
+      expect(console.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not warn when there is no token to send', () => {
+      withAuthorizationHeader(
+        {},
+        auth({ allowInsecure: true, token: null }),
+        'http://localhost:8787/__down'
       );
 
-      fresh({}, { token: null, allowInsecure: true }, 'http://localhost/__down');
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when sending was never enabled', () => {
+      withAuthorizationHeader(
+        {},
+        auth({ allowInsecure: true, enabled: undefined }),
+        'http://localhost:8787/__down'
+      );
 
       expect(console.warn).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
The optional `authorizationToken` was appended to request URLs as a `jwt` query
parameter. Request URLs are routinely persisted well outside the request itself
— server-side request logs, tracing span tags, error-reporting breadcrumbs — so
a bearer credential travelling in one leaks into every system that records a
URL.

This moves the token to an `Authorization: Bearer` header on the requests that
need it: the download/upload measurement requests, the load-generating
requests that run alongside them, the TURN credential fetch, and the two
logging endpoints.

Because the token is now withheld from any endpoint that isn't known to be
HTTPS, a new `allowInsecureAuthorizationToken` option (default `false`) opts
back in for local development against an `http://` server. It warns once when
it takes effect.

A token alone is not enough to send one: the new `authorizationEnabled` option
(`'header' | boolean`, default `undefined`) has to opt in. `true` is a permanent
alias for `'header'` rather than "whatever the default transport is", so a
transport added later cannot silently change what an existing config does.

All three options are marked experimental — `@experimental` in the JSDoc, which
reaches the published `.d.ts`, and 🧪 in the README. Note `authorizationToken`
already shipped in v1.13.0, so this is a retroactive relabel rather than a new
option being introduced as unstable.

