### PR TITLE
ci: unbreak Bonk by bumping the pinned OpenCode version

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,7 +47,8 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          # Dots, not hyphens: `claude-opus-4-8` does not resolve.
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4.7"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -53,7 +53,10 @@ jobs:
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          # 1.15.13 stopped initializing the provider around 2026-08-18 (see
+          # ask-bonk#226); every run since produced zero tokens and an empty
+          # comment. 1.18.18 is the version that diagnostic verified working.
+          opencode_version: 1.18.18
           prompt: |
             Review this pull request. Summarize what it changes and flag any
             correctness, security, or style issues as inline review comments.


### PR DESCRIPTION
Bonk has failed on every run since 2026-08-18. The last success was
2026-07-31 — eight consecutive failures. The failure was silent from the
outside: it posted an empty comment followed by "check the logs for details",
and the logs contained no error either, which is why it went unnoticed for
three weeks.

Two things were wrong, and the first was hiding the second.

The pinned OpenCode 1.15.13 swallowed the underlying error, emitting only
`loop { step: 0 }` and zero tokens. `bonk.yml` had not been modified since it
was added, and `cloudflare/workers-sdk` fails identically while pinning a
March action SHA, so neither this repo's config nor the action code was the
cause — what both broken repos shared was that pin. ask-bonk#226 tracked the
same provider-initialization failures on 2026-08-18 and verified 1.18.18.

Bumping the pin immediately surfaced the actual fault:

```
Model not found: cloudflare-ai-gateway/anthropic/claude-opus-4-8.
Did you mean: anthropic/claude-opus-4.5, anthropic/claude-opus-4.6,
anthropic/claude-opus-4.7?
```

The version component is dot-separated, and 4.8 does not exist. This is
presumably a gateway-side catalog change, since the id resolved until July 31.
Moving to 4.7, the newest offered.

The version stays pinned rather than moving to `latest`, since floating is what
produced this drift. Worth keeping the diagnostic value in mind though: 1.15.13
reported nothing at all, while 1.18.18 named the problem on the first run.
