### PR TITLE
ci: unbreak Bonk (switch to Workers AI)

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,7 +47,8 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          # Dots, not hyphens: `claude-opus-4-8` does not resolve.
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4.7"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,17 +47,19 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          # Dots, not hyphens: `claude-opus-4-8` does not resolve.
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4.7"
+          # Workers AI, not Anthropic: the gateway's upstream Anthropic key is
+          # invalid, so anthropic/* returns authentication_error regardless of
+          # the model id. Mirrors the working cloudflare-docs configuration.
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
-          # 1.15.13 stopped initializing the provider around 2026-08-18 (see
-          # ask-bonk#226); every run since produced zero tokens and an empty
-          # comment. 1.18.18 is the version that diagnostic verified working.
-          opencode_version: 1.18.18
+          # 1.15.13 reported nothing at all when the model call failed, which
+          # hid this breakage for three weeks. 1.17.7 is the version running
+          # green in cloudflare-docs against the same model.
+          opencode_version: "1.17.7"
           prompt: |
             Review this pull request. Summarize what it changes and flag any
             correctness, security, or style issues as inline review comments.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -53,7 +53,10 @@ jobs:
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          # 1.15.13 stopped initializing the provider around 2026-08-18 (see
+          # ask-bonk#226); every run since produced zero tokens and an empty
+          # comment. 1.18.18 is the version that diagnostic verified working.
+          opencode_version: 1.18.18
           prompt: |
             Review this pull request. Summarize what it changes and flag any
             correctness, security, or style issues as inline review comments.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -49,8 +49,9 @@ jobs:
         with:
           # Workers AI, not Anthropic: the gateway's upstream Anthropic key is
           # invalid, so anthropic/* returns authentication_error regardless of
-          # the model id. Code-optimized variant, same price as kimi-k2.6.
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code"
+          # the model id. k2.6 over the newer k2.7-code: the latter answers
+          # "LGTM!" without the summary the prompt asks for, on diffs of any size.
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -49,8 +49,8 @@ jobs:
         with:
           # Workers AI, not Anthropic: the gateway's upstream Anthropic key is
           # invalid, so anthropic/* returns authentication_error regardless of
-          # the model id. Mirrors the working cloudflare-docs configuration.
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
+          # the model id. Code-optimized variant, same price as kimi-k2.6.
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write
@@ -58,7 +58,7 @@ jobs:
           token_permissions: NO_PUSH
           # 1.15.13 reported nothing at all when the model call failed, which
           # hid this breakage for three weeks. 1.17.7 is the version running
-          # green in cloudflare-docs against the same model.
+          # green in cloudflare-docs.
           opencode_version: "1.17.7"
           prompt: |
             Review this pull request. Summarize what it changes and flag any

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,19 @@ re-indent every workflow.
   4. On merge, the publish workflow auto-creates a git tag and publishes to npm.
 - **Do NOT** push directly to `main` — the branch ruleset blocks direct pushes.
   All changes must go through a pull request.
+
+## AI review (Bonk)
+
+`.github/workflows/bonk.yml` reviews PRs automatically on open, and on demand
+when someone with write access comments `/bonk`.
+
+Two things to know before editing that workflow:
+
+- It runs on **Workers AI**, not Anthropic. The AI Gateway's upstream Anthropic
+  key is invalid, so any `anthropic/*` model returns `authentication_error`
+  regardless of the model id.
+- **Comment-triggered runs execute the workflow from `main`,** because
+  `issue_comment` is a repository-level event. Changes to this file cannot be
+  tested with `/bonk` on a PR — only the `pull_request: [opened]` trigger uses
+  the branch copy, and it does not fire on pushes to an open PR. Verifying a
+  change means opening a fresh PR.


### PR DESCRIPTION
Bonk has failed on every run since 2026-08-18. Three faults stacked, each
hiding the next.

The pinned OpenCode 1.15.13 reported nothing on failure — empty comment, no
error in the logs — which is why this went unnoticed for three weeks. Bumping
it surfaced the second fault: `claude-opus-4-8` is not a valid id, the version
component is dot-separated. Fixing that reached the provider and exposed the
real one:

```
AI_APICallError: Invalid Anthropic API Key
```

The `CF_AI_GATEWAY_*` secrets are fine; the gateway's upstream Anthropic key is
not, so every `anthropic/*` model fails regardless of id. That also explains why
cloudflare-docs' `bigbonk.yml` (anthropic) has never executed while its
`bonk.yml` (Workers AI) is green.

So this moves to Workers AI on the same `kimi-k2.6` / 1.17.7 pair cloudflare-docs
runs green. The code-optimized `kimi-k2.7-code` was tried and reverted: it wins
on coding benchmarks but answers `LGTM!` without the summary the prompt asks
for, on a 2-line diff and a 20-line one alike. Its advertised 30% reduction in
reasoning tokens seems to cost exactly the analysis a review wants.

AGENTS.md picks up the two things that are not evident from the workflow file:
the Anthropic provider is unusable through this gateway, and comment-triggered
runs execute main's copy of the workflow, so changes to it cannot be verified
with `/bonk` on a PR.

One cosmetic leftover: the `title` sub-agent still defaults to Anthropic and
logs an error, which does not affect the review.
