### PR TITLE
test: evaluate gpt-5.6-sol for Bonk (do not merge)

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,7 +47,8 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          # Dots, not hyphens: `claude-opus-4-8` does not resolve.
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4.7"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,17 +47,19 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          # Dots, not hyphens: `claude-opus-4-8` does not resolve.
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4.7"
+          # Workers AI, not Anthropic: the gateway's upstream Anthropic key is
+          # invalid, so anthropic/* returns authentication_error regardless of
+          # the model id. Mirrors the working cloudflare-docs configuration.
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
-          # 1.15.13 stopped initializing the provider around 2026-08-18 (see
-          # ask-bonk#226); every run since produced zero tokens and an empty
-          # comment. 1.18.18 is the version that diagnostic verified working.
-          opencode_version: 1.18.18
+          # 1.15.13 reported nothing at all when the model call failed, which
+          # hid this breakage for three weeks. 1.17.7 is the version running
+          # green in cloudflare-docs against the same model.
+          opencode_version: "1.17.7"
           prompt: |
             Review this pull request. Summarize what it changes and flag any
             correctness, security, or style issues as inline review comments.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -53,7 +53,10 @@ jobs:
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          # 1.15.13 stopped initializing the provider around 2026-08-18 (see
+          # ask-bonk#226); every run since produced zero tokens and an empty
+          # comment. 1.18.18 is the version that diagnostic verified working.
+          opencode_version: 1.18.18
           prompt: |
             Review this pull request. Summarize what it changes and flag any
             correctness, security, or style issues as inline review comments.

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -49,8 +49,9 @@ jobs:
         with:
           # Workers AI, not Anthropic: the gateway's upstream Anthropic key is
           # invalid, so anthropic/* returns authentication_error regardless of
-          # the model id. Code-optimized variant, same price as kimi-k2.6.
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code"
+          # the model id. k2.6 over the newer k2.7-code: the latter answers
+          # "LGTM!" without the summary the prompt asks for, on diffs of any size.
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -49,8 +49,8 @@ jobs:
         with:
           # Workers AI, not Anthropic: the gateway's upstream Anthropic key is
           # invalid, so anthropic/* returns authentication_error regardless of
-          # the model id. Mirrors the working cloudflare-docs configuration.
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
+          # the model id. Code-optimized variant, same price as kimi-k2.6.
+          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write
@@ -58,7 +58,7 @@ jobs:
           token_permissions: NO_PUSH
           # 1.15.13 reported nothing at all when the model call failed, which
           # hid this breakage for three weeks. 1.17.7 is the version running
-          # green in cloudflare-docs against the same model.
+          # green in cloudflare-docs.
           opencode_version: "1.17.7"
           prompt: |
             Review this pull request. Summarize what it changes and flag any

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,11 +47,11 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          # Workers AI, not Anthropic: the gateway's upstream Anthropic key is
+          # OpenAI, not Anthropic: the gateway's upstream Anthropic key is
           # invalid, so anthropic/* returns authentication_error regardless of
-          # the model id. k2.6 over the newer k2.7-code: the latter answers
-          # "LGTM!" without the summary the prompt asks for, on diffs of any size.
-          model: "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6"
+          # the model id. The OpenAI key works — workerd, cf, workers-py,
+          # cloudflare-os and vinext all review through it.
+          model: "cloudflare-ai-gateway/openai/gpt-5.6-sol"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write

--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -41,26 +41,36 @@ jobs:
           persist-credentials: false
 
       - name: Run Bonk
-        uses: ask-bonk/ask-bonk/github@main
+        # Pinned rather than @main: this workflow runs privileged with the
+        # gateway secrets available.
+        uses: ask-bonk/ask-bonk/github@5d4fe8f4a557afb1b73ec8c0ffcf60359a28865f # main
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
+          # Deny interactive questions and doom loops; nothing here can answer
+          # a prompt, and a loop just burns the 30 minute timeout.
+          OPENCODE_CONFIG_CONTENT: '{"permission":{"external_directory":{"/home/runner/work/**":"allow"},"question":"deny","doom_loop":"deny"}}'
         with:
           # OpenAI, not Anthropic: the gateway's upstream Anthropic key is
           # invalid, so anthropic/* returns authentication_error regardless of
-          # the model id. The OpenAI key works — workerd, cf, workers-py,
-          # cloudflare-os and vinext all review through it.
-          model: "cloudflare-ai-gateway/openai/gpt-5.6-sol"
+          # the model id.
+          #
+          # terra, not the larger sol: sol rejects function tools whenever
+          # reasoning_effort is set on /v1/chat/completions, which is fatal for
+          # a reviewer that needs to read files. This is the workerd pairing.
+          model: "cloudflare-ai-gateway/openai/gpt-5.6-terra"
+          variant: "high"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
           # 1.15.13 reported nothing at all when the model call failed, which
-          # hid this breakage for three weeks. 1.17.7 is the version running
-          # green in cloudflare-docs.
-          opencode_version: "1.17.7"
+          # hid this breakage for three weeks. The dev build is what workerd
+          # runs against these models.
+          opencode_dev: true
+          opencode_version: "latest"
           prompt: |
             Review this pull request. Summarize what it changes and flag any
             correctness, security, or style issues as inline review comments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,19 @@ re-indent every workflow.
   4. On merge, the publish workflow auto-creates a git tag and publishes to npm.
 - **Do NOT** push directly to `main` — the branch ruleset blocks direct pushes.
   All changes must go through a pull request.
+
+## AI review (Bonk)
+
+`.github/workflows/bonk.yml` reviews PRs automatically on open, and on demand
+when someone with write access comments `/bonk`.
+
+Two things to know before editing that workflow:
+
+- It runs on **Workers AI**, not Anthropic. The AI Gateway's upstream Anthropic
+  key is invalid, so any `anthropic/*` model returns `authentication_error`
+  regardless of the model id.
+- **Comment-triggered runs execute the workflow from `main`,** because
+  `issue_comment` is a repository-level event. Changes to this file cannot be
+  tested with `/bonk` on a PR — only the `pull_request: [opened]` trigger uses
+  the branch copy, and it does not fire on pushes to an open PR. Verifying a
+  change means opening a fresh PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,9 @@ Two things to know before editing that workflow:
 - It runs on **OpenAI**, not Anthropic. The AI Gateway's upstream Anthropic key
   is invalid, so any `anthropic/*` model returns `authentication_error`
   regardless of the model id. The OpenAI and Workers AI providers both work.
+- The model is `gpt-5.6-terra`, not the larger `gpt-5.6-sol`. Sol returns 400
+  for function tools whenever `reasoning_effort` is set on
+  `/v1/chat/completions`, so a reviewer that needs to read files cannot use it.
 - **Comment-triggered runs execute the workflow from `main`,** because
   `issue_comment` is a repository-level event. Changes to this file cannot be
   tested with `/bonk` on a PR — only the `pull_request: [opened]` trigger uses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,9 @@ when someone with write access comments `/bonk`.
 
 Two things to know before editing that workflow:
 
-- It runs on **Workers AI**, not Anthropic. The AI Gateway's upstream Anthropic
-  key is invalid, so any `anthropic/*` model returns `authentication_error`
-  regardless of the model id.
+- It runs on **OpenAI**, not Anthropic. The AI Gateway's upstream Anthropic key
+  is invalid, so any `anthropic/*` model returns `authentication_error`
+  regardless of the model id. The OpenAI and Workers AI providers both work.
 - **Comment-triggered runs execute the workflow from `main`,** because
   `issue_comment` is a repository-level event. Changes to this file cannot be
   tested with `/bonk` on a PR — only the `pull_request: [opened]` trigger uses


### PR DESCRIPTION
Test PR, **not for merge** — #149 is the real change and stays open.

#149 revealed that the AI Gateway's Anthropic key is invalid, so Bonk moved to
Workers AI on `kimi-k2.6`. The gateway's OpenAI key does work, though: workerd,
cf, workers-py, cloudflare-os and vinext all review through
`cloudflare-ai-gateway/openai/gpt-5.6-*`, using the same `CF_AI_GATEWAY_*`
secret names and OIDC endpoint we do.

This branch is #149 with one line changed, the model, so the review it produces
is directly comparable to the `kimi-k2.6` one on #149. `variant` stays unset
even though workerd and cloudflare-os pair GPT with `variant: high` — reasoning
effort is worth testing, but as its own axis rather than a confound here.

Close once we have picked a model.
