### PR TITLE
fix: unbreak Bonk

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -47,13 +47,15 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          model: "cloudflare-ai-gateway/openai/gpt-5.6-terra"
+          variant: "high"
           mentions: "/bonk,@ask-bonk"
           # Only users with write access may invoke Bonk via comment.
           permissions: write
           # Review-only: Bonk leaves comments/suggestions but never pushes commits.
           token_permissions: NO_PUSH
-          opencode_version: 1.15.13 # pin to this version as certain ones cause ProviderInitError issues
+          # Don't pin: 1.15.13 silently reported nothing when the model call failed.
+          opencode_version: "latest"
           prompt: |
             Review this pull request. Summarize what it changes and flag any
             correctness, security, or style issues as inline review comments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,19 @@ re-indent every workflow.
   4. On merge, the publish workflow auto-creates a git tag and publishes to npm.
 - **Do NOT** push directly to `main` — the branch ruleset blocks direct pushes.
   All changes must go through a pull request.
+
+## AI review (Bonk)
+
+`.github/workflows/bonk.yml` reviews PRs automatically on open, and on demand
+when someone with write access comments `/bonk`.
+
+Before editing that workflow:
+
+- The gateway's Anthropic key is invalid — `anthropic/*` returns
+  `authentication_error` for any model id. OpenAI and Workers AI both work.
+- Use `gpt-5.6-terra`, not `gpt-5.6-sol`: sol returns 400 for function tools
+  whenever `reasoning_effort` is set.
+- **Comment-triggered runs execute `main`'s copy of the workflow**, since
+  `issue_comment` is a repository-level event. Only `pull_request: [opened]`
+  uses the branch copy, and it does not fire on pushes to an open PR — so
+  verifying a change to this file means opening a fresh PR.


### PR DESCRIPTION
Bonk has posted nothing since 2026-08-18. Three faults stacked, each hiding the
next: OpenCode 1.15.13 reported nothing at all on failure, `claude-opus-4-8` is
not a valid model id, and the gateway's upstream Anthropic key is invalid, so
every `anthropic/*` model fails auth regardless of id.

Moves to `gpt-5.6-terra` with `variant: high`, matching workerd. Not the larger
`gpt-5.6-sol`, which returns 400 for function tools whenever `reasoning_effort`
is set — fatal for a reviewer that reads files, and why sol has no working run
anywhere in the org.
